### PR TITLE
增加了评论过长折叠展开按钮以及一些其他小调整.

### DIFF
--- a/src/BiliLite.UWP/Controls/CommentControl.xaml
+++ b/src/BiliLite.UWP/Controls/CommentControl.xaml
@@ -336,12 +336,12 @@
                                                     <TextBlock  Margin="4 0">删除</TextBlock>
                                                 </StackPanel>
                                             </HyperlinkButton>
-                                            <HyperlinkButton Foreground="Gray" >
+                                            <!--<HyperlinkButton Foreground="Gray" >
                                                 <StackPanel Orientation="Horizontal">
 
                                                     <TextBlock  Margin="4 0">举报</TextBlock>
                                                 </StackPanel>
-                                            </HyperlinkButton>
+                                            </HyperlinkButton>-->
 
                                         </StackPanel>
 

--- a/src/BiliLite.UWP/Controls/CommentControl.xaml
+++ b/src/BiliLite.UWP/Controls/CommentControl.xaml
@@ -214,6 +214,7 @@
                     OneRowModeEnabled="True"
                     ItemHeight="80"
                     ItemsSource="{x:Bind Path=Content.Pictures}"
+                    Visibility="{x:Bind Path=Content.ShowPictures}"
                     SelectionMode="None"
                     ItemClick="NotePicturesView_ItemClick"
                     IsItemClickEnabled="True">

--- a/src/BiliLite.UWP/Controls/CommentControl.xaml
+++ b/src/BiliLite.UWP/Controls/CommentControl.xaml
@@ -206,10 +206,10 @@
                     <RowDefinition Height="auto"/>
                 </Grid.RowDefinitions>
 
-                <ContentControl Grid.Row="0" Margin="4 0" Content="{Binding Path=RealText}" Visibility="Visible">
+                <ContentControl Grid.Row="0" Margin="4 0" Content="{Binding Path=CommentText,Mode=OneWay}" Visibility="Visible">
                 </ContentControl>
 
-                <HyperlinkButton Grid.Row="1" Click="BtnExpand_Click" HorizontalContentAlignment="Left" Content="展开" Visibility="{x:Bind Path=ShowExpandBtn}">
+                <HyperlinkButton Grid.Row="1" Command="{x:Bind CommentExpandCommand}" Foreground="{ThemeResource LinkTextColor}"  HorizontalContentAlignment="Left" Content="{x:Bind ExtendBtnText,Mode=OneWay}" Visibility="{x:Bind Path=IsContentNeedExpand,Mode=OneWay}">
                 </HyperlinkButton>
 
                 <toolkit:AdaptiveGridView
@@ -314,10 +314,10 @@
                                                 <Run Text="{Binding Path=ReplyControl.Location}"></Run>
                                     </TextBlock>
                                     <!--<TextBlock Text="{Binding Path=content.message}" IsTextSelectionEnabled="True" TextWrapping="Wrap"></TextBlock>-->
-                                    <ContentControl Margin="0 8 0 0" Content="{Binding Path=RealText}" Visibility="Visible">
+                                    <ContentControl Margin="0 8 0 0" Content="{Binding Path=CommentText,Mode=OneWay}" Visibility="Visible">
                                     </ContentControl>
 
-                                    <HyperlinkButton Click="BtnExpand_Click" HorizontalContentAlignment="Left" Content="展开" Visibility="{Binding Path=ShowExpandBtn}">
+                                    <HyperlinkButton Command="{Binding CommentExpandCommand}" Foreground="{ThemeResource LinkTextColor}"  HorizontalContentAlignment="Left" Content="{Binding ExtendBtnText}" Visibility="{Binding Path=IsContentNeedExpand,Mode=OneWay}">
                                     </HyperlinkButton>
 
                                     <Grid>
@@ -344,16 +344,7 @@
                                                     <TextBlock  Margin="4 0">删除</TextBlock>
                                                 </StackPanel>
                                             </HyperlinkButton>
-                                            <!--<HyperlinkButton Foreground="Gray" >
-                                                <StackPanel Orientation="Horizontal">
-
-                                                    <TextBlock  Margin="4 0">举报</TextBlock>
-                                                </StackPanel>
-                                            </HyperlinkButton>-->
-
                                         </StackPanel>
-
-
 
                                     </Grid>
 

--- a/src/BiliLite.UWP/Controls/CommentControl.xaml
+++ b/src/BiliLite.UWP/Controls/CommentControl.xaml
@@ -214,7 +214,7 @@
                     OneRowModeEnabled="True"
                     ItemHeight="80"
                     ItemsSource="{x:Bind Path=Content.Pictures}"
-                    Visibility="{x:Bind Path=Content.ShowPictures}"
+                    Visibility="{x:Bind Path=ShowPics}"
                     SelectionMode="None"
                     ItemClick="NotePicturesView_ItemClick"
                     IsItemClickEnabled="True">

--- a/src/BiliLite.UWP/Controls/CommentControl.xaml
+++ b/src/BiliLite.UWP/Controls/CommentControl.xaml
@@ -203,12 +203,17 @@
                     <RowDefinition Height="auto"/>
                     <RowDefinition Height="auto"/>
                     <RowDefinition Height="auto"/>
+                    <RowDefinition Height="auto"/>
                 </Grid.RowDefinitions>
-                <ContentControl  Grid.Row="0" Margin="4 0" Content="{x:Bind Path=Content.Text}">
 
+                <ContentControl Grid.Row="0" Margin="4 0" Content="{Binding Path=RealText}" Visibility="Visible">
                 </ContentControl>
+
+                <HyperlinkButton Grid.Row="1" Click="BtnExpand_Click" HorizontalContentAlignment="Left" Content="展开" Visibility="{x:Bind Path=ShowExpandBtn}">
+                </HyperlinkButton>
+
                 <toolkit:AdaptiveGridView
-                    Grid.Row="1" 
+                    Grid.Row="2" 
                     x:Name="NotePicturesView"
                     StretchContentForSingleRow="False"
                     OneRowModeEnabled="True"
@@ -232,7 +237,7 @@
                     </toolkit:AdaptiveGridView.ItemTemplate>
                 </toolkit:AdaptiveGridView>
 
-                <Grid Margin="0 8 0 0" Grid.Row="2">
+                <Grid Margin="0 8 0 0" Grid.Row="3">
                     <StackPanel Orientation="{Binding ElementName=CommentControlContent, Path=DataContext.CommentActionOrientation}" VerticalAlignment="Center">
 
                         <HyperlinkButton  Click="BtnLike_Click" Foreground="{x:Bind LikeColor,Mode=OneWay}" ToolTipService.ToolTip="{x:Bind Like}" Margin="4 0 8 0" HorizontalContentAlignment="Left">
@@ -267,7 +272,7 @@
 
                 </Grid>
 
-                <StackPanel Grid.Row="3" Margin="0 4" Background="#19AAAAAA" Padding="8" Visibility="{x:Bind Path=ShowReplies,Mode=OneWay}">
+                <StackPanel Grid.Row="4" Margin="0 4" Background="#19AAAAAA" Padding="8" Visibility="{x:Bind Path=ShowReplies,Mode=OneWay}">
 
                     <StackPanel  Visibility="{x:Bind Path=ShowReplyBox,Mode=OneWay}" Margin="0 0 0 4">
                         <TextBox MaxLength="233" BorderThickness="0" TextWrapping="Wrap"  Text="{x:Bind Path=ReplyText,Mode=TwoWay}" FontSize="14" MinHeight="48" PlaceholderText="说点什么吧..." AcceptsReturn="True"></TextBox>
@@ -309,9 +314,11 @@
                                                 <Run Text="{Binding Path=ReplyControl.Location}"></Run>
                                     </TextBlock>
                                     <!--<TextBlock Text="{Binding Path=content.message}" IsTextSelectionEnabled="True" TextWrapping="Wrap"></TextBlock>-->
-                                    <ContentControl Margin="0 8 0 0" Content="{Binding Path=Content.Text}">
-
+                                    <ContentControl Margin="0 8 0 0" Content="{Binding Path=RealText}" Visibility="Visible">
                                     </ContentControl>
+
+                                    <HyperlinkButton Click="BtnExpand_Click" HorizontalContentAlignment="Left" Content="展开" Visibility="{Binding Path=ShowExpandBtn}">
+                                    </HyperlinkButton>
 
                                     <Grid>
                                         <StackPanel Margin="0 4" Orientation="Horizontal">

--- a/src/BiliLite.UWP/Controls/CommentControl.xaml.cs
+++ b/src/BiliLite.UWP/Controls/CommentControl.xaml.cs
@@ -580,23 +580,6 @@ namespace BiliLite.Controls
             }
         }
 
-        private void BtnExpand_Click(object sender, RoutedEventArgs e)
-        {
-            var btn = sender as HyperlinkButton;
-            var m = btn.DataContext as CommentViewModel;
-            if (m.IsExpand)
-            {
-                btn.Content = "展开";
-                m.RealText = m.ShortComment;
-            }
-            else
-            {
-                btn.Content = "收起";
-                m.RealText = m.Content.Text;
-            }
-            m.IsExpand = !m.IsExpand;
-        }
-
         #endregion
 
         #region Public Methods

--- a/src/BiliLite.UWP/Controls/CommentControl.xaml.cs
+++ b/src/BiliLite.UWP/Controls/CommentControl.xaml.cs
@@ -580,6 +580,23 @@ namespace BiliLite.Controls
             }
         }
 
+        private void BtnExpand_Click(object sender, RoutedEventArgs e)
+        {
+            var btn = sender as HyperlinkButton;
+            var m = btn.DataContext as CommentViewModel;
+            if (m.IsExpand)
+            {
+                btn.Content = "展开";
+                m.RealText = m.ShortComment;
+            }
+            else
+            {
+                btn.Content = "收起";
+                m.RealText = m.Content.Text;
+            }
+            m.IsExpand = !m.IsExpand;
+        }
+
         #endregion
 
         #region Public Methods

--- a/src/BiliLite.UWP/Models/Common/SettingConstants.cs
+++ b/src/BiliLite.UWP/Models/Common/SettingConstants.cs
@@ -91,6 +91,21 @@ namespace BiliLite.Models.Common
             /// 浏览器打开无法处理的链接
             /// </summary>
             public const string OPEN_URL_BROWSER = "OpenUrlWithBrowser";
+
+            /// <summary>
+            /// 启用长评论收起
+            /// </summary>
+            public const string ENABLE_COMMENT_SHRINK = "EnableCommentShrink";
+
+            /// <summary>
+            /// 收起评论长度
+            /// </summary>
+            public const string COMMENT_SHRINK_LENGTH = "CommentShrinkLength";
+
+            /// <summary>
+            /// 默认收起评论长度
+            /// </summary>
+            public const int COMMENT_SHRINK_DEFAULT_LENGTH = 75;
         }
 
         public class Account

--- a/src/BiliLite.UWP/Models/Common/SettingConstants.cs
+++ b/src/BiliLite.UWP/Models/Common/SettingConstants.cs
@@ -93,17 +93,17 @@ namespace BiliLite.Models.Common
             public const string OPEN_URL_BROWSER = "OpenUrlWithBrowser";
 
             /// <summary>
-            /// 启用长评论收起
+            /// 启用长评论折叠
             /// </summary>
             public const string ENABLE_COMMENT_SHRINK = "EnableCommentShrink";
 
             /// <summary>
-            /// 收起评论长度
+            /// 折叠评论长度
             /// </summary>
             public const string COMMENT_SHRINK_LENGTH = "CommentShrinkLength";
 
             /// <summary>
-            /// 默认收起评论长度
+            /// 默认折叠评论长度
             /// </summary>
             public const int COMMENT_SHRINK_DEFAULT_LENGTH = 75;
         }

--- a/src/BiliLite.UWP/Pages/SettingPage.xaml
+++ b/src/BiliLite.UWP/Pages/SettingPage.xaml
@@ -171,12 +171,12 @@
                             </StackPanel>
 
                             <StackPanel  Margin="0 0 0 8">
-                                <TextBlock  Margin="0 8"  FontSize="16">启用长评论收起</TextBlock>
+                                <TextBlock  Margin="0 8"  FontSize="16">启用长评论折叠</TextBlock>
                                 <ToggleSwitch x:Name="swEnableCommentShrink" ></ToggleSwitch>
                             </StackPanel>
 
                             <StackPanel  Margin="0 0 0 8">
-                                <TextBlock  Margin="0 8" FontSize="16">评论收起长度</TextBlock>
+                                <TextBlock  Margin="0 8" FontSize="16">评论折叠长度</TextBlock>
                                 <controls:NumberBox x:Name="numCommentShrinkLength" Minimum="0"  Width="200" HorizontalAlignment="Left" Value="0" SpinButtonPlacementMode="Compact" SmallChange="1" ></controls:NumberBox>
                             </StackPanel>
 

--- a/src/BiliLite.UWP/Pages/SettingPage.xaml
+++ b/src/BiliLite.UWP/Pages/SettingPage.xaml
@@ -169,6 +169,17 @@
                                     </ComboBox.Items>
                                 </ComboBox>
                             </StackPanel>
+
+                            <StackPanel  Margin="0 0 0 8">
+                                <TextBlock  Margin="0 8"  FontSize="16">启用长评论收起</TextBlock>
+                                <ToggleSwitch x:Name="swEnableCommentShrink" ></ToggleSwitch>
+                            </StackPanel>
+
+                            <StackPanel  Margin="0 0 0 8">
+                                <TextBlock  Margin="0 8" FontSize="16">评论收起长度</TextBlock>
+                                <controls:NumberBox x:Name="numCommentShrinkLength" Minimum="0"  Width="200" HorizontalAlignment="Left" Value="0" SpinButtonPlacementMode="Compact" SmallChange="1" ></controls:NumberBox>
+                            </StackPanel>
+
                             <StackPanel  Margin="0 0 0 8">
                                 <TextBlock  Margin="0 8"  FontSize="16">新窗口打开图片预览</TextBlock>
                                 <ToggleSwitch x:Name="swPreviewImageNavigateToPage" ></ToggleSwitch>

--- a/src/BiliLite.UWP/Pages/SettingPage.xaml.cs
+++ b/src/BiliLite.UWP/Pages/SettingPage.xaml.cs
@@ -189,7 +189,7 @@ namespace BiliLite.Pages
 
             // 鼠标中键/侧键行为
             cbMouseMiddleAction.SelectedIndex = SettingService.GetValue(SettingConstants.UI.MOUSE_MIDDLE_ACTION, (int)MouseMiddleActions.Back);
-            cbDetailDisplay.Loaded += new RoutedEventHandler((sender, e) =>
+            cbMouseMiddleAction.Loaded += new RoutedEventHandler((sender, e) =>
             {
                 cbMouseMiddleAction.SelectionChanged += new SelectionChangedEventHandler((obj, args) =>
                 {
@@ -206,6 +206,26 @@ namespace BiliLite.Pages
                     SettingService.SetValue(SettingConstants.UI.DETAIL_DISPLAY, cbDetailDisplay.SelectedIndex);
                 });
             });
+
+            // 启用长评论收起
+            swEnableCommentShrink.IsOn = SettingService.GetValue(SettingConstants.UI.ENABLE_COMMENT_SHRINK, true);
+            swEnableCommentShrink.Loaded += (sender, e) =>
+            {
+                swEnableCommentShrink.Toggled += (obj, args) =>
+                {
+                    SettingService.SetValue(SettingConstants.UI.ENABLE_COMMENT_SHRINK, swEnableCommentShrink.IsOn);
+                };
+            };
+
+            // 评论收起长度
+            numCommentShrinkLength.Value = SettingService.GetValue(SettingConstants.UI.COMMENT_SHRINK_LENGTH, SettingConstants.UI.COMMENT_SHRINK_DEFAULT_LENGTH);
+            numCommentShrinkLength.Loaded += (sender, e) =>
+            {
+                numCommentShrinkLength.ValueChanged += (obj, args) =>
+                {
+                    SettingService.SetValue(SettingConstants.UI.COMMENT_SHRINK_LENGTH, (int)numCommentShrinkLength.Value);
+                };
+            };
 
             //动态显示
             cbDynamicDisplayMode.SelectedIndex = SettingService.GetValue<int>(SettingConstants.UI.DYNAMIC_DISPLAY_MODE, 0);

--- a/src/BiliLite.UWP/Themes/Dark.xaml
+++ b/src/BiliLite.UWP/Themes/Dark.xaml
@@ -13,6 +13,7 @@
     <Color x:Key="HighLightTextColor">#FFFFFFFF</Color>
     <Color x:Key="DefaultTextColor">#CC000000</Color>
     <Color x:Key="SystemColorHighLightColor">#ec407a</Color>
+    <Color x:Key="LinkTextColor">#008ac5</Color>
 
     <SolidColorBrush x:Key="NavigationViewTopPaneBackground" Color="{ThemeResource TopPaneBackground}" />
     <Color x:Key="NoTapGridBackground">#FF282828</Color>

--- a/src/BiliLite.UWP/Themes/Light.xaml
+++ b/src/BiliLite.UWP/Themes/Light.xaml
@@ -13,6 +13,7 @@
     <Color x:Key="HighLightTextColor">#FFFFFFFF</Color>
     <Color x:Key="DefaultTextColor">#CC000000</Color>
     <Color x:Key="SystemColorHighLightColor">#ec407a</Color>
+    <Color x:Key="LinkTextColor">#008ac5</Color>
 
     <SolidColorBrush x:Key="NavigationViewTopPaneBackground" Color="{ThemeResource TopPaneBackground}" />
     <Color x:Key="NoTapGridBackground">#FFF9F9F9</Color>

--- a/src/BiliLite.UWP/ViewModels/Comment/CommentContentViewModel.cs
+++ b/src/BiliLite.UWP/ViewModels/Comment/CommentContentViewModel.cs
@@ -12,20 +12,6 @@ namespace BiliLite.ViewModels.Comment
     public class CommentContentViewModel : BaseViewModel
     {
         public List<NotePicture> Pictures { get; set; }
-        public Visibility ShowPictures
-        { 
-            get 
-            {
-                if (Pictures.Count > 0)
-                {
-                    return Visibility.Visible;
-                }
-                else
-                { 
-                    return Visibility.Collapsed; 
-                }
-            } 
-        }
         public string Message { get; set; }
         public int Plat { get; set; }
 

--- a/src/BiliLite.UWP/ViewModels/Comment/CommentContentViewModel.cs
+++ b/src/BiliLite.UWP/ViewModels/Comment/CommentContentViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using BiliLite.Extensions;
 using BiliLite.Models.Common;
@@ -11,6 +12,20 @@ namespace BiliLite.ViewModels.Comment
     public class CommentContentViewModel : BaseViewModel
     {
         public List<NotePicture> Pictures { get; set; }
+        public Visibility ShowPictures
+        { 
+            get 
+            {
+                if (Pictures.Count > 0)
+                {
+                    return Visibility.Visible;
+                }
+                else
+                { 
+                    return Visibility.Collapsed; 
+                }
+            } 
+        }
         public string Message { get; set; }
         public int Plat { get; set; }
 

--- a/src/BiliLite.UWP/ViewModels/Comment/CommentViewModel.cs
+++ b/src/BiliLite.UWP/ViewModels/Comment/CommentViewModel.cs
@@ -176,6 +176,20 @@ namespace BiliLite.ViewModels.Comment
 
         public RelayCommand<object> LaunchUrlCommand { get; private set; }
 
+        public bool ShowPics 
+        {
+            get
+            {
+                if (Content.Pictures.Count > 0)
+                {
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+        }
         private async void ButtonClick(object paramenter)
         {
             await MessageCenter.HandelUrl(paramenter.ToString());

--- a/src/BiliLite.UWP/ViewModels/Comment/CommentViewModel.cs
+++ b/src/BiliLite.UWP/ViewModels/Comment/CommentViewModel.cs
@@ -3,10 +3,12 @@ using System.Collections.ObjectModel;
 using Windows.UI;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Controls;
 using BiliLite.Models.Common.Comment;
 using BiliLite.Modules;
 using BiliLite.Services;
 using BiliLite.ViewModels.Common;
+using BiliLite.Extensions;
 using PropertyChanged;
 
 namespace BiliLite.ViewModels.Comment
@@ -188,6 +190,57 @@ namespace BiliLite.ViewModels.Comment
                 {
                     return false;
                 }
+            }
+        }
+        public int ExpandLength { get; set; } = 75;
+        public bool ShowExpandBtn
+        {
+            get
+            {
+                if (Content.Message.Length > ExpandLength)
+                {
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+        }
+        public RichTextBlock ShortComment
+        {
+            get
+            {
+                if (ShowExpandBtn)
+                {
+                    return (Content.Message.Substring(0, ExpandLength) + "...").ToRichTextBlock(Content.Emote);
+                }
+                else
+                {
+                    return Content.Text;
+                }
+            }
+        }
+        public bool IsExpand { get; set; } = false;
+
+        private RichTextBlock _RealText;
+        public RichTextBlock RealText
+        {
+            get 
+            {
+                if (_RealText == null) 
+                {
+                    return ShortComment;
+                }
+                else
+                {
+                    return _RealText;
+                }
+            }
+            set
+            {
+                _RealText = value;
+                OnPropertyChanged("RealText");
             }
         }
         private async void ButtonClick(object paramenter)


### PR DESCRIPTION
主要更改:
1. 注释掉了楼中楼中的"举报"按钮.
这个按钮实际上没有绑定任何功能, 在自己发的楼中楼评论中还会出现按钮重叠的问题, 因此先注释掉了.
~举报也不是好事~

2. 在评论没有图片时不会显示图片的滑条控件
大部分评论是没有图片的, 然而不管有没有图片都会有图片的滑条, 感觉既占位置又很丑, 因此加了个简单的判断在没有图片时隐藏掉了.

3. 加入了评论过长展开按钮.
解决 #150 这个需求. 
目前折叠的阈值是纯文本的75字符. 后面可以加入自定义此阈值的选项.

目前问题有: 
1. 对于不是纯文本的内容, 有可能被意外截断. ~我感觉影响不大~
   ![image](https://github.com/ywmoyue/biliuwp-lite/assets/82302542/0292eeda-1864-405e-9166-a4008153da1a)
2.  似乎这个展开按钮的排布还是有点丑...

本地测试暂时没有什么问题. 可以的话请多测试几次.



