### PR TITLE
修复了在某些up主的视频下无推荐视频和无法分享的错误

### DIFF
--- a/src/BiliLite.UWP/Models/Requests/Api/VideoAPI.cs
+++ b/src/BiliLite.UWP/Models/Requests/Api/VideoAPI.cs
@@ -29,6 +29,17 @@ namespace BiliLite.Models.Requests.Api
             return api;
         }
 
+        public ApiModel RelatesWebInterface(string id, bool isBvId)
+        {
+            ApiModel api = new ApiModel()
+            {
+                method = RestSharp.Method.Get,
+                baseUrl = $"https://api.bilibili.com/x/web-interface/archive/related",
+                parameter = $"&{(isBvId ? "bvid=" : "aid=")}{id}"
+            };
+            return api;
+        }
+
         public ApiModel DetailProxy(string id, bool isbvid)
         {
             ApiModel api = new ApiModel()

--- a/src/BiliLite.UWP/ViewModels/Video/VideoDetailPageViewModel.cs
+++ b/src/BiliLite.UWP/ViewModels/Video/VideoDetailPageViewModel.cs
@@ -227,9 +227,21 @@ namespace BiliLite.Modules
                 {
                     // 通过web获取视频详情
                     var webResult = await videoAPI.DetailWebInterface(id, isbvid).Request();
-                    if (webResult.status)
+                    // 通过web获取推荐视频
+                    var webRelatesResult = await videoAPI.RelatesWebInterface(id, isbvid).Request();
+                    if (webResult.status && webRelatesResult.status)
                     {
                         data = await webResult.GetJson<ApiDataModel<VideoDetailModel>>();
+                        data.data.ShortLink = "https://b23.tv/" + data.data.Bvid;
+
+                        // 解析推荐视频
+                        var relatesData = await webRelatesResult.GetJson<ApiDataModel<List<VideoDetailRelatesModel>>>();
+                        if (!relatesData.success)
+                        {
+                            throw new CustomizedErrorException(relatesData.message);
+                        }
+                        data.data.Relates = relatesData.data;
+
                         needGetUserReq = true;
                     }
                 }


### PR DESCRIPTION
Fixed #290 .
原因应该是默认的api返回为空，回落到了备用的api上， 
而这个api没有提供ShortLink短链接和Relates推荐视频的项。

用了一个新api,介绍在这里: https://github.com/SocialSisterYi/bilibili-API-collect/blob/c2d9291c0026350e07c01e59fc8a3ee0e0cd42f1/docs/video/recommend.md 

本地测试了 #290  中提到的两个up主，都正常。