### PR TITLE
修复点击直播中右侧主播按钮导致整个应用崩溃的问题

### DIFF
--- a/src/BiliLite.UWP/Extensions/StringExtensions.cs
+++ b/src/BiliLite.UWP/Extensions/StringExtensions.cs
@@ -307,6 +307,16 @@ namespace BiliLite.Extensions
             return color;
         }
 
+        /// <summary>
+        /// 是否为正确格式的url
+        /// </summary>
+        /// <param name="url"></param>
+        /// <returns></returns>
+        public static bool IsUrl(this string url)
+        {
+            return Uri.TryCreate(url, UriKind.Absolute, out Uri _);
+        }
+
         #region Private methods
 
         /// <summary>

--- a/src/BiliLite.UWP/Models/Common/Live/LiveAnchorProfileGloryInfo.cs
+++ b/src/BiliLite.UWP/Models/Common/Live/LiveAnchorProfileGloryInfo.cs
@@ -1,6 +1,6 @@
-﻿using BiliLite.Services;
+﻿using BiliLite.Extensions;
+using BiliLite.Services;
 using Newtonsoft.Json;
-using System;
 
 namespace BiliLite.Models.Common.Live
 {
@@ -26,14 +26,7 @@ namespace BiliLite.Models.Common.Live
             get => jumpUrl;
             set
             {
-                if (Uri.TryCreate(value, UriKind.Absolute, out Uri _))
-                {
-                    jumpUrl = value;
-                }
-                else
-                {
-                    jumpUrl = ApiHelper.NOT_FOUND_URL;
-                }
+                jumpUrl = value.IsUrl() ? value : ApiHelper.NOT_FOUND_URL;
             }
         }
     }

--- a/src/BiliLite.UWP/Models/Common/Live/LiveAnchorProfileGloryInfo.cs
+++ b/src/BiliLite.UWP/Models/Common/Live/LiveAnchorProfileGloryInfo.cs
@@ -1,4 +1,6 @@
-﻿using Newtonsoft.Json;
+﻿using BiliLite.Services;
+using Newtonsoft.Json;
+using System;
 
 namespace BiliLite.Models.Common.Live
 {
@@ -17,7 +19,22 @@ namespace BiliLite.Models.Common.Live
         [JsonProperty("pic_url")]
         public string PicUrl { get; set; }
 
+        private string jumpUrl;
         [JsonProperty("jump_url")]
-        public string JumpUrl { get; set; }
+        public string JumpUrl
+        {
+            get => jumpUrl;
+            set
+            {
+                if (Uri.TryCreate(value, UriKind.Absolute, out Uri _))
+                {
+                    jumpUrl = value;
+                }
+                else
+                {
+                    jumpUrl = ApiHelper.NOT_FOUND_URL;
+                }
+            }
+        }
     }
 }

--- a/src/BiliLite.UWP/Models/Common/UpdateJsonAddressOptions.cs
+++ b/src/BiliLite.UWP/Models/Common/UpdateJsonAddressOptions.cs
@@ -12,8 +12,8 @@ namespace BiliLite.Models.Common
             new UpdateJsonAddressOption() { Name = "[镜像]kgithub", Value = ApiHelper.KGITHUB_GIT_RAW_URL },
         };
 
-        // 优先使用更稳定的ghproxy
-        public const string DEFAULT_UPDATE_JSON_ADDRESS = ApiHelper.GHPROXY_GIT_RAW_URL;
+        // 优先使用服务器在香港腾讯云的kgithub
+        public const string DEFAULT_UPDATE_JSON_ADDRESS = ApiHelper.KGITHUB_GIT_RAW_URL;
 
         public static UpdateJsonAddressOption GetOption(string type)
         {

--- a/src/BiliLite.UWP/Models/Common/UpdateJsonAddressOptions.cs
+++ b/src/BiliLite.UWP/Models/Common/UpdateJsonAddressOptions.cs
@@ -12,8 +12,8 @@ namespace BiliLite.Models.Common
             new UpdateJsonAddressOption() { Name = "[镜像]kgithub", Value = ApiHelper.KGITHUB_GIT_RAW_URL },
         };
 
-        // 优先使用服务器在香港腾讯云的kgithub
-        public const string DEFAULT_UPDATE_JSON_ADDRESS = ApiHelper.KGITHUB_GIT_RAW_URL;
+        // 优先使用更稳定的ghproxy
+        public const string DEFAULT_UPDATE_JSON_ADDRESS = ApiHelper.GHPROXY_GIT_RAW_URL;
 
         public static UpdateJsonAddressOption GetOption(string type)
         {

--- a/src/BiliLite.UWP/Services/ApiHelper.cs
+++ b/src/BiliLite.UWP/Services/ApiHelper.cs
@@ -27,6 +27,9 @@ namespace BiliLite.Services
         // 哔哩哔哩API
         public const string API_BASE_URL = "https://api.bilibili.com";
 
+        // 哔哩哔哩404页面
+        public const string NOT_FOUND_URL = "https://www.bilibili.com/404";
+
         //漫游默认的服务器
         public const string ROMAING_PROXY_URL = "https://b.chuchai.vip";
 


### PR DESCRIPTION
#378
10月19日新出的一个主播荣誉:
![image](https://github.com/ywmoyue/biliuwp-lite/assets/82302542/f4409ee9-d7e6-4f12-b7c0-5665305238da)
其中的jump_url不合法，为"/”，导致整个应用崩溃。 

现在会检测其是否为正确的url, 不正确会被替换为404页面。