### PR TITLE
更换了ghproxy的最新地址

### DIFF
--- a/src/BiliLite.UWP/Pages/SettingPage.xaml.cs
+++ b/src/BiliLite.UWP/Pages/SettingPage.xaml.cs
@@ -1002,7 +1002,7 @@ namespace BiliLite.Pages
                 case ApiHelper.GHPROXY_GIT_RAW_URL:
                     {
                         mirrorDonateText.Visibility = Visibility.Visible;
-                        mirrorDonateUrl.NavigateUri = new Uri("https://ghproxy.com/donate");
+                        mirrorDonateUrl.NavigateUri = new Uri("https://gh-proxy.com");
                         break;
                     }
                 case ApiHelper.KGITHUB_GIT_RAW_URL:

--- a/src/BiliLite.UWP/Services/ApiHelper.cs
+++ b/src/BiliLite.UWP/Services/ApiHelper.cs
@@ -21,7 +21,7 @@ namespace BiliLite.Services
         public const string GIT_RAW_URL = "https://raw.githubusercontent.com/ywmoyue/biliuwp-lite/master";
 
         // 镜像 GIT RAW路径
-        public const string GHPROXY_GIT_RAW_URL = "https://ghproxy.com/https://raw.githubusercontent.com/ywmoyue/biliuwp-lite/master";
+        public const string GHPROXY_GIT_RAW_URL = "https://gh-proxy.com/https://raw.githubusercontent.com/ywmoyue/biliuwp-lite/master";
         public const string KGITHUB_GIT_RAW_URL = "https://raw.kkgithub.com/ywmoyue/biliuwp-lite/master";
 
         // 哔哩哔哩API


### PR DESCRIPTION
刚说完ghproxy稳定，他就不稳定了……全球均无法访问。
gh-proxy.com 我测试其服务器也是甲骨文韩国的，应该是同一作者。 
由于gh-proxy似乎没有捐赠地址，因此换成了其项目主页。
测试了一下，应该可以保证全国大部分地区正常获取更新文件。
![image](https://github.com/ywmoyue/biliuwp-lite/assets/82302542/f8d9ce79-1d9f-4aaa-960b-bb75b1077bfa)
