### PR TITLE
修复在某些视频加载评论导致应用崩溃的问题

### DIFF
--- a/src/BiliLite.UWP/Extensions/StringExtensions.cs
+++ b/src/BiliLite.UWP/Extensions/StringExtensions.cs
@@ -93,6 +93,9 @@ namespace BiliLite.Extensions
                     input = input.Replace(">", "&gt;");
                     input = input.Replace("\r\n", "<LineBreak/>");
                     input = input.Replace("\n", "<LineBreak/>");
+                    //处理其他控制字符
+                    input = Regex.Replace(input, @"\p{C}+", string.Empty);
+
                     //处理链接
                     input = HandelUrl(input);
 


### PR DESCRIPTION
"像个知道自己犯错的小孩坦然面对该有的惩罚\u0014[笑哭]"

此句评论中的控制字符导致了应用崩溃。
所以在进行必要的\r \n 替换后，将剩余的其他控制字符删除应该可以解决这个问题。
应该不会对其他视频评论区产生影响。如果有问题请修改，谢谢！
close #395 