### PR TITLE
直播右侧弹幕栏更新一些内容

### DIFF
--- a/src/BiliLite.UWP/Extensions/StringExtensions.cs
+++ b/src/BiliLite.UWP/Extensions/StringExtensions.cs
@@ -93,7 +93,7 @@ namespace BiliLite.Extensions
                     input = input.Replace("\r\n", "<LineBreak/>");
                     input = input.Replace("\n", "<LineBreak/>");
                     //处理其他控制字符
-                    input = Regex.Replace(input, @"\p{C}+", string.Empty);
+                    input = Regex.Replace(input, @"[\p{Cc}\p{Cf}]", string.Empty);
 
                     //处理链接
                     if (!IsLive) { input = HandelUrl(input); }
@@ -105,7 +105,7 @@ namespace BiliLite.Extensions
                     if (!IsLive) { input = HandelVideoID(input); }
 
                     //生成xaml
-                    var xaml = string.Format(@" <RichTextBlock HorizontalAlignment=""Stretch"" TextWrapping=""Wrap""  xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation""
+                    var xaml = string.Format(@"<RichTextBlock HorizontalAlignment=""Stretch"" TextWrapping=""Wrap""  xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation""
                                                xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml"" xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
                                                xmlns:mc = ""http://schemas.openxmlformats.org/markup-compatibility/2006"" LineHeight=""{1}"">
                                                <Paragraph>{0}</Paragraph>

--- a/src/BiliLite.UWP/Models/Common/Live/DanmuMsgModel.cs
+++ b/src/BiliLite.UWP/Models/Common/Live/DanmuMsgModel.cs
@@ -1,6 +1,8 @@
 ﻿using System.Linq;
 using Windows.UI.Xaml;
 using BiliLite.ViewModels.Live;
+using Newtonsoft.Json.Linq;
+using Windows.UI.Xaml.Controls;
 
 namespace BiliLite.Models.Common.Live
 {
@@ -10,6 +12,11 @@ namespace BiliLite.Models.Common.Live
         /// 内容文本
         /// </summary>
         public string Text { get; set; }
+
+        /// <summary>
+        /// 将Text经过处理后的富文本
+        /// </summary>
+        public RichTextBlock RichText { get; set; }
 
         /// <summary>
         /// 弹幕颜色，默认白色
@@ -67,26 +74,45 @@ namespace BiliLite.Models.Common.Live
         public string MedalColor { get; set; }
         
         /// <summary>
-        /// 用户上舰名称
+        /// 用户上的舰的名称
         /// </summary>
         public string UserCaptain {  get; set; }
 
-        public string UserCaptainImage
-        {
-            get
-            {
-                if (UserCaptain == null)
-                {
-                    return null;
-                }
+        /// <summary>
+        /// 用户上的舰的图片
+        /// </summary>
+        public string UserCaptainImage {  get; set; }
 
-                return UserCaptain switch
-                {
-                    "舰长" => "/Assets/Live/ic_live_guard_3.png",
-                    "提督" => "/Assets/Live/ic_live_guard_2.png",
-                    "总督" => "/Assets/Live/ic_live_guard_1.png",
-                    _ => null,
-                };
+        /// <summary>
+        /// 黄豆表情
+        /// </summary>
+        public JContainer Emoji {  get; set; }
+
+        /// <summary>
+        /// 各类大表情
+        /// </summary>
+        public BigStickerInfo BigSticker {  get; set; }
+
+        public class BigStickerInfo
+        {
+            public string Url { get; set; }
+            public int Height { get; set; }
+            public int Width { get; set; }
+        }
+
+        /// <summary>
+        /// 是否显示富文本(用于用户发出大表情时)
+        /// </summary>
+        public Visibility ShowRichText { get; set; } = Visibility.Visible;
+
+        /// <summary>
+        /// 是否显示大表情
+        /// </summary>
+        
+        public Visibility ShowBigSticker
+        {
+            get {
+                return (ShowRichText == Visibility.Visible) ? Visibility.Collapsed : Visibility.Visible;
             }
         }
 

--- a/src/BiliLite.UWP/Models/Common/Live/DanmuMsgModel.cs
+++ b/src/BiliLite.UWP/Models/Common/Live/DanmuMsgModel.cs
@@ -26,15 +26,15 @@ namespace BiliLite.Models.Common.Live
         /// </summary>
         public string UserNameColor { get; set; } = "#FF808080";
 
-        /// <summary>
-        /// 等级
-        /// </summary>
-        public string UserLevel { get; set; }
+        ///// <summary>
+        ///// 等级
+        ///// </summary>
+        //public string UserLevel { get; set; }
 
-        /// <summary>
-        /// 等级颜色,默认灰色
-        /// </summary>
-        public string UserLevelColor { get; set; } = "#FF808080";
+        ///// <summary>
+        ///// 等级颜色,默认灰色
+        ///// </summary>
+        //public string UserLevelColor { get; set; } = "#FF808080";
 
         /// <summary>
         /// 用户头衔id（对应的是CSS名）
@@ -65,12 +65,40 @@ namespace BiliLite.Models.Common.Live
         /// 勋章颜色
         /// </summary>
         public string MedalColor { get; set; }
+        
+        /// <summary>
+        /// 用户上舰名称
+        /// </summary>
+        public string UserCaptain {  get; set; }
 
+        public string UserCaptainImage
+        {
+            get
+            {
+                if (UserCaptain == null)
+                {
+                    return null;
+                }
+
+                return UserCaptain switch
+                {
+                    "舰长" => "/Assets/Live/ic_live_guard_3.png",
+                    "提督" => "/Assets/Live/ic_live_guard_2.png",
+                    "总督" => "/Assets/Live/ic_live_guard_1.png",
+                    _ => null,
+                };
+            }
+        }
 
         /// <summary>
         /// 是否显示房管
         /// </summary>
         public Visibility ShowAdmin { get; set; } = Visibility.Collapsed;
+
+        /// <summary>
+        /// 是否显示舰长
+        /// </summary>
+        public Visibility ShowCaptain { get; set; } = Visibility.Collapsed;
 
         /// <summary>
         /// 是否显示勋章

--- a/src/BiliLite.UWP/Models/Common/Live/DanmuMsgModel.cs
+++ b/src/BiliLite.UWP/Models/Common/Live/DanmuMsgModel.cs
@@ -109,12 +109,7 @@ namespace BiliLite.Models.Common.Live
         /// 是否显示大表情
         /// </summary>
         
-        public Visibility ShowBigSticker
-        {
-            get {
-                return (ShowRichText == Visibility.Visible) ? Visibility.Collapsed : Visibility.Visible;
-            }
-        }
+        public Visibility ShowBigSticker => (ShowRichText == Visibility.Visible) ? Visibility.Collapsed : Visibility.Visible;
 
         /// <summary>
         /// 是否显示房管

--- a/src/BiliLite.UWP/Modules/Live/LiveMessage.cs
+++ b/src/BiliLite.UWP/Modules/Live/LiveMessage.cs
@@ -164,14 +164,19 @@ namespace BiliLite.Modules.Live
                 {
                     var msg = new DanmuMsgModel();
                     if (obj["info"] != null && obj["info"].ToArray().Length != 0)
-                    {
+                    {   
+                        // 弹幕内容
+                        // TODO 支持表情
                         msg.Text = obj["info"][1].ToString();
+
+                        // 弹幕颜色
                         var color = obj["info"][0][3].ToInt32();
                         if (color != 0)
                         {
                             msg.DanmuColor = color.ToString();
                         }
 
+                        // 是否为房管
                         if (obj["info"][2] != null && obj["info"][2].ToArray().Length != 0)
                         {
                             msg.UserName = obj["info"][2][1].ToString() + ":";
@@ -181,6 +186,25 @@ namespace BiliLite.Modules.Live
                                 msg.ShowAdmin = Visibility.Visible;
                             }
                         }
+
+                        // 是否为舰长
+                        if (obj["info"][3][10] != null && Convert.ToInt32(obj["info"][3][10].ToString()) != 0)
+                        {
+                            switch (Convert.ToInt32(obj["info"][3][10].ToString())){
+                                case 3:
+                                    msg.UserCaptain = "舰长";
+                                    break;
+                                case 2:
+                                    msg.UserCaptain = "提督";
+                                    break;
+                                case 1:
+                                    msg.UserCaptain = "总督";
+                                    break;
+                            }
+                            msg.ShowCaptain = Visibility.Visible;
+                        }
+
+                        // 粉丝牌
                         if (obj["info"][3] != null && obj["info"][3].ToArray().Length != 0)
                         {
                             msg.MedalName = obj["info"][3][1].ToString();
@@ -188,11 +212,15 @@ namespace BiliLite.Modules.Live
                             msg.MedalColor = obj["info"][3][4].ToString();
                             msg.ShowMedal = Visibility.Visible;
                         }
-                        if (obj["info"][4] != null && obj["info"][4].ToArray().Length != 0)
-                        {
-                            msg.UserLevel = "UL" + obj["info"][4][0].ToString();
-                            msg.UserLevelColor = obj["info"][4][2].ToString();
-                        }
+
+                        // 用户直播等级(已经被b站弃用)
+                        //if (obj["info"][4] != null && obj["info"][4].ToArray().Length != 0)
+                        //{
+                        //    msg.UserLevel = "UL" + obj["info"][4][0].ToString();
+                        //    msg.UserLevelColor = obj["info"][4][2].ToString();
+                        //}
+
+                        // 用户头衔
                         if (obj["info"][5] != null && obj["info"][5].ToArray().Length != 0)
                         {
                             msg.UserTitleID = obj["info"][5][0].ToString();

--- a/src/BiliLite.UWP/Modules/Live/LiveMessage.cs
+++ b/src/BiliLite.UWP/Modules/Live/LiveMessage.cs
@@ -164,10 +164,36 @@ namespace BiliLite.Modules.Live
                 {
                     var msg = new DanmuMsgModel();
                     if (obj["info"] != null && obj["info"].ToArray().Length != 0)
-                    {   
+                    {
+                        // 弹幕内黄豆表情详情
+                        if (obj["info"][0][15]["extra"] != null)// && obj["info"][0][15]["extra"].ToArray().Length != 0)
+                        {
+                            var extra = JObject.Parse(obj["info"][0][15]["extra"].ToString());
+                            if (extra["emots"].ToArray().Length != 0)
+                            {
+                                msg.Emoji = (JContainer)extra["emots"];
+                            }
+                        }
+
+                        // 弹幕内大表情详情
+                        if (obj["info"][0][13] != null && obj["info"][0][13].ToArray().Length != 0)
+                        {
+                            // 如果有大表情, 直接不需要显示任何文字
+                            msg.ShowRichText = Visibility.Collapsed;
+                            msg.BigSticker = new DanmuMsgModel.BigStickerInfo
+                            {
+                                Url = (string)obj["info"][0][13]["url"],
+                                Height = (int)obj["info"][0][13]["height"], 
+                                Width = (int)obj["info"][0][13]["width"], 
+                            };
+                            //有的表情特别大 :(
+                            msg.BigSticker.Height = (msg.BigSticker.Height * 60 / msg.BigSticker.Width).ToInt32(); 
+                            msg.BigSticker.Width = 60;
+                        }
+
                         // 弹幕内容
-                        // TODO 支持表情
                         msg.Text = obj["info"][1].ToString();
+                        msg.RichText = StringExtensions.ToRichTextBlock(msg.Text, (JObject)msg.Emoji, true);
 
                         // 弹幕颜色
                         var color = obj["info"][0][3].ToInt32();
@@ -193,12 +219,15 @@ namespace BiliLite.Modules.Live
                             switch (Convert.ToInt32(obj["info"][3][10].ToString())){
                                 case 3:
                                     msg.UserCaptain = "舰长";
+                                    msg.UserCaptainImage = "/Assets/Live/ic_live_guard_3.png";
                                     break;
                                 case 2:
                                     msg.UserCaptain = "提督";
+                                    msg.UserCaptainImage = "/Assets/Live/ic_live_guard_2.png";
                                     break;
                                 case 1:
                                     msg.UserCaptain = "总督";
+                                    msg.UserCaptainImage = "/Assets/Live/ic_live_guard_1.png";
                                     break;
                             }
                             msg.ShowCaptain = Visibility.Visible;
@@ -220,12 +249,12 @@ namespace BiliLite.Modules.Live
                         //    msg.UserLevelColor = obj["info"][4][2].ToString();
                         //}
 
-                        // 用户头衔
-                        if (obj["info"][5] != null && obj["info"][5].ToArray().Length != 0)
-                        {
-                            msg.UserTitleID = obj["info"][5][0].ToString();
-                            msg.ShowTitle = Visibility.Visible;
-                        }
+                        // 用户头衔(基本没用)
+                        //if (obj["info"][5] != null && obj["info"][5].ToArray().Length != 0)
+                        //{
+                        //    msg.UserTitleID = obj["info"][5][0].ToString();
+                        //    msg.ShowTitle = Visibility.Visible;
+                        //}
 
                         NewMessage?.Invoke(MessageType.Danmu, msg);
                         return;

--- a/src/BiliLite.UWP/Pages/LiveDetailPage.xaml
+++ b/src/BiliLite.UWP/Pages/LiveDetailPage.xaml
@@ -306,14 +306,19 @@
                                     </Grid>
                                 </Grid>
                             </Border>
+                            <!--<Border Visibility="{x:Bind ShowCaptain}" BorderThickness="1" BorderBrush="DodgerBlue" Background="DodgerBlue" Margin="0 0 4 0" CornerRadius="2" Padding="2">
+                                <TextBlock FontSize="12" Foreground="White" Text="{x:Bind UserCaptain}"></TextBlock>
+                            </Border>-->
+                            <Image Visibility="{x:Bind ShowCaptain}" Height="24" VerticalAlignment="Center" Margin="0 0 4 0" Source="{Binding UserCaptainImage}"></Image>
                             <Image Visibility="{x:Bind ShowTitle}" Height="20" VerticalAlignment="Center" Margin="0 0 4 0" Source="{Binding UserTitleImage}"></Image>
-                            <Border  Visibility="{x:Bind ShowUserLevel}" BorderThickness="1" VerticalAlignment="Center" BorderBrush="{x:Bind Path=UserLevelColor,Converter={StaticResource colorConvert}}" Margin="0 0 4 0" CornerRadius="2" Padding="2 0">
+                            <!--<Border  Visibility="{x:Bind ShowUserLevel}" BorderThickness="1" VerticalAlignment="Center" BorderBrush="{x:Bind Path=UserLevelColor,Converter={StaticResource colorConvert}}" Margin="0 0 4 0" CornerRadius="2" Padding="2 0">
                                 <TextBlock FontSize="12" Foreground="{x:Bind Path=UserLevelColor,Converter={StaticResource colorConvert}}" Text="{x:Bind UserLevel}"></TextBlock>
-                            </Border>
+                            </Border>-->
                             <!--<TextBlock TextWrapping="WrapWholeWords"><Run  Foreground="Gray"  Text="{Binding username}"></Run></TextBlock>-->
                         </StackPanel>
                     </InlineUIContainer>
                     <Run Foreground="{x:Bind Path=UserNameColor,Converter={StaticResource colorConvert}}" Text="{x:Bind UserName}"></Run>
+                    <Run Text=" "></Run>
                     <Run Text="{x:Bind Text}"></Run>
                 </Paragraph>
             </RichTextBlock>
@@ -922,8 +927,8 @@
                                             </Button>
                                         </DataTemplate>
                                     </ItemsControl.ItemTemplate>
-                                    
-                                    
+
+
                                 </ItemsControl>
                             </ScrollViewer>
 
@@ -942,8 +947,8 @@
                                     </Style>
                                 </ListView.ItemContainerStyle>
                             </ListView>
-                            
-                            
+
+
                             <ListView ItemsSource="{x:Bind Path=m_liveRoomViewModel.GiftMessage,Mode=OneWay}" SelectionMode="None" IsItemClickEnabled="False" Visibility="{x:Bind Path=m_liveRoomViewModel.ShowGiftMessage,Mode=OneWay}" Grid.Row="2" >
                                 <ListView.ItemsPanel>
                                     <ItemsPanelTemplate>
@@ -1116,7 +1121,26 @@
                     </PivotItem>
                 </Pivot>
             </Grid>
-
+            <toolkit:GridSplitter
+                IsEnabled="True"
+                x:Name="RightInfoGridSplitter"
+                GripperCursor="Default"
+                HorizontalAlignment="Left"
+                Grid.Column="1"
+                ResizeDirection="Auto"
+                ResizeBehavior="BasedOnAlignment"
+                CursorBehavior="ChangeOnSplitterHover"
+                Width="16">     
+                <toolkit:GridSplitter.Background>
+                    <SolidColorBrush Opacity="0"></SolidColorBrush>
+                </toolkit:GridSplitter.Background>
+                <toolkit:GridSplitter.GripperForeground>
+                    <SolidColorBrush Opacity="0"></SolidColorBrush>
+                </toolkit:GridSplitter.GripperForeground>
+                <toolkit:GridSplitter.RenderTransform>
+                    <TranslateTransform X="-8" />
+                </toolkit:GridSplitter.RenderTransform>
+            </toolkit:GridSplitter>
         </Grid>
         <ProgressRing IsActive="True"  HorizontalAlignment="Center" VerticalAlignment="Center" Visibility="{x:Bind Path=m_liveRoomViewModel.Loading,Mode=OneWay}"></ProgressRing>
     </Grid>

--- a/src/BiliLite.UWP/Pages/LiveDetailPage.xaml
+++ b/src/BiliLite.UWP/Pages/LiveDetailPage.xaml
@@ -285,43 +285,55 @@
             </Setter>
         </Style>
         <DataTemplate x:Key="chat" x:Name="chat" x:DataType="live:DanmuMsgModel">
-            <RichTextBlock TextWrapping="Wrap" Margin="4 0" LineHeight="24">
-                <Paragraph>
-                    <InlineUIContainer >
-                        <StackPanel  Orientation="Horizontal" VerticalAlignment="Center" Padding="0 0 0 -4">
-                            <Border Visibility="{x:Bind ShowAdmin}" BorderThickness="1" BorderBrush="DarkOrange" Background="DarkOrange" Margin="0 0 4 0" CornerRadius="2" Padding="2">
-                                <TextBlock FontSize="12" Foreground="White">房管</TextBlock>
-                            </Border>
-                            <Border Visibility="{x:Bind ShowMedal}" VerticalAlignment="Center" BorderThickness="1" BorderBrush="{x:Bind Path=MedalColor,Converter={StaticResource colorConvert}}" CornerRadius="2" Margin="0 0 4 0">
-                                <Grid>
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition/>
-                                        <ColumnDefinition/>
-                                    </Grid.ColumnDefinitions>
-                                    <Grid Background="{x:Bind Path=MedalColor,Converter={StaticResource colorConvert}}" Padding="2 0">
-                                        <TextBlock FontSize="12" Foreground="White" Text="{x:Bind MedalName}"></TextBlock>
+            <toolkit:WrapPanel Orientation="Horizontal">
+                <RichTextBlock TextWrapping="Wrap" Margin="4 0" LineHeight="24">
+                    <Paragraph>
+                        <InlineUIContainer>
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Padding="0 0 0 -4">
+                                <Border Visibility="{x:Bind ShowAdmin}" BorderThickness="1" BorderBrush="DarkOrange" Background="DarkOrange" Margin="0 0 4 0" CornerRadius="2" Padding="2">
+                                    <TextBlock FontSize="12" Foreground="White">房管</TextBlock>
+                                </Border>
+                                <Border Visibility="{x:Bind ShowMedal}" VerticalAlignment="Center" BorderThickness="1" BorderBrush="{x:Bind Path=MedalColor,Converter={StaticResource colorConvert}}" CornerRadius="2" Margin="0 0 4 0">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition/>
+                                            <ColumnDefinition/>
+                                        </Grid.ColumnDefinitions>
+                                        <Grid Background="{x:Bind Path=MedalColor,Converter={StaticResource colorConvert}}" Padding="2 0">
+                                            <TextBlock FontSize="12" Foreground="White" Text="{x:Bind MedalName}"></TextBlock>
+                                        </Grid>
+                                        <Grid Grid.Column="1" Background="White" Padding="4 0">
+                                            <TextBlock FontSize="12" Foreground="{x:Bind Path=MedalColor,Converter={StaticResource colorConvert}}" Text="{x:Bind MedalLevel}"></TextBlock>
+                                        </Grid>
                                     </Grid>
-                                    <Grid Grid.Column="1" Background="White" Padding="4 0">
-                                        <TextBlock FontSize="12" Foreground="{x:Bind Path=MedalColor,Converter={StaticResource colorConvert}}" Text="{x:Bind MedalLevel}"></TextBlock>
-                                    </Grid>
-                                </Grid>
-                            </Border>
-                            <!--<Border Visibility="{x:Bind ShowCaptain}" BorderThickness="1" BorderBrush="DodgerBlue" Background="DodgerBlue" Margin="0 0 4 0" CornerRadius="2" Padding="2">
+                                </Border>
+                                <!--<Border Visibility="{x:Bind ShowCaptain}" BorderThickness="1" BorderBrush="DodgerBlue" Background="DodgerBlue" Margin="0 0 4 0" CornerRadius="2" Padding="2">
                                 <TextBlock FontSize="12" Foreground="White" Text="{x:Bind UserCaptain}"></TextBlock>
                             </Border>-->
-                            <Image Visibility="{x:Bind ShowCaptain}" Height="24" VerticalAlignment="Center" Margin="0 0 4 0" Source="{Binding UserCaptainImage}"></Image>
-                            <Image Visibility="{x:Bind ShowTitle}" Height="20" VerticalAlignment="Center" Margin="0 0 4 0" Source="{Binding UserTitleImage}"></Image>
-                            <!--<Border  Visibility="{x:Bind ShowUserLevel}" BorderThickness="1" VerticalAlignment="Center" BorderBrush="{x:Bind Path=UserLevelColor,Converter={StaticResource colorConvert}}" Margin="0 0 4 0" CornerRadius="2" Padding="2 0">
+                                <Image Visibility="{x:Bind ShowCaptain}" Height="24" VerticalAlignment="Center" Margin="0 0 4 0" Source="{Binding UserCaptainImage}"></Image>
+                                <!--<Image Visibility="{x:Bind ShowTitle}" Height="20" VerticalAlignment="Center" Margin="0 0 2 0" Source="{Binding UserTitleImage}"></Image>-->
+                                <!--<Border  Visibility="{x:Bind ShowUserLevel}" BorderThickness="1" VerticalAlignment="Center" BorderBrush="{x:Bind Path=UserLevelColor,Converter={StaticResource colorConvert}}" Margin="0 0 4 0" CornerRadius="2" Padding="2 0">
                                 <TextBlock FontSize="12" Foreground="{x:Bind Path=UserLevelColor,Converter={StaticResource colorConvert}}" Text="{x:Bind UserLevel}"></TextBlock>
                             </Border>-->
-                            <!--<TextBlock TextWrapping="WrapWholeWords"><Run  Foreground="Gray"  Text="{Binding username}"></Run></TextBlock>-->
-                        </StackPanel>
-                    </InlineUIContainer>
-                    <Run Foreground="{x:Bind Path=UserNameColor,Converter={StaticResource colorConvert}}" Text="{x:Bind UserName}"></Run>
-                    <Run Text=" "></Run>
-                    <Run Text="{x:Bind Text}"></Run>
-                </Paragraph>
-            </RichTextBlock>
+                                <!--<TextBlock TextWrapping="WrapWholeWords"><Run  Foreground="Gray"  Text="{Binding username}"></Run></TextBlock>-->
+                                <TextBlock Margin="0 2 -4 0" Foreground="{x:Bind Path=UserNameColor,Converter={StaticResource colorConvert}}" Text="{x:Bind UserName}"></TextBlock>
+                            </StackPanel>
+                        </InlineUIContainer>
+                        <!--<Run Text=" "></Run>
+                        <Run Text="{x:Bind Text}"></Run>-->
+                    </Paragraph>
+                </RichTextBlock>
+                <RichTextBlock TextWrapping="Wrap" Margin="4 2 4 0">
+                    <Paragraph>
+                        <InlineUIContainer>
+                            <StackPanel>
+                                <ContentControl Content="{Binding Path=RichText,Mode=OneWay}" Visibility="{x:Bind ShowRichText}"></ContentControl>
+                                <Image Visibility="{x:Bind ShowBigSticker}" Source="{Binding BigSticker.Url}" Height="{x:Bind BigSticker.Height}" Width="{x:Bind BigSticker.Width}"></Image>
+                            </StackPanel>
+                        </InlineUIContainer>
+                    </Paragraph>
+                </RichTextBlock>
+            </toolkit:WrapPanel>
         </DataTemplate>
     </Page.Resources>
     <Grid>

--- a/src/BiliLite.UWP/Pages/LiveDetailPage.xaml
+++ b/src/BiliLite.UWP/Pages/LiveDetailPage.xaml
@@ -289,7 +289,7 @@
                 <RichTextBlock TextWrapping="Wrap" Margin="4 0" LineHeight="24">
                     <Paragraph>
                         <InlineUIContainer>
-                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Padding="0 0 0 -4">
+                            <StackPanel  Orientation="Horizontal" VerticalAlignment="Center" Padding="0 0 0 -4">
                                 <Border Visibility="{x:Bind ShowAdmin}" BorderThickness="1" BorderBrush="DarkOrange" Background="DarkOrange" Margin="0 0 4 0" CornerRadius="2" Padding="2">
                                     <TextBlock FontSize="12" Foreground="White">房管</TextBlock>
                                 </Border>
@@ -308,13 +308,13 @@
                                     </Grid>
                                 </Border>
                                 <!--<Border Visibility="{x:Bind ShowCaptain}" BorderThickness="1" BorderBrush="DodgerBlue" Background="DodgerBlue" Margin="0 0 4 0" CornerRadius="2" Padding="2">
-                                <TextBlock FontSize="12" Foreground="White" Text="{x:Bind UserCaptain}"></TextBlock>
-                            </Border>-->
+                                    <TextBlock FontSize="12" Foreground="White" Text="{x:Bind UserCaptain}"></TextBlock>
+                                </Border>-->
                                 <Image Visibility="{x:Bind ShowCaptain}" Height="24" VerticalAlignment="Center" Margin="0 0 4 0" Source="{Binding UserCaptainImage}"></Image>
                                 <!--<Image Visibility="{x:Bind ShowTitle}" Height="20" VerticalAlignment="Center" Margin="0 0 2 0" Source="{Binding UserTitleImage}"></Image>-->
                                 <!--<Border  Visibility="{x:Bind ShowUserLevel}" BorderThickness="1" VerticalAlignment="Center" BorderBrush="{x:Bind Path=UserLevelColor,Converter={StaticResource colorConvert}}" Margin="0 0 4 0" CornerRadius="2" Padding="2 0">
-                                <TextBlock FontSize="12" Foreground="{x:Bind Path=UserLevelColor,Converter={StaticResource colorConvert}}" Text="{x:Bind UserLevel}"></TextBlock>
-                            </Border>-->
+                                    <TextBlock FontSize="12" Foreground="{x:Bind Path=UserLevelColor,Converter={StaticResource colorConvert}}" Text="{x:Bind UserLevel}"></TextBlock>
+                                </Border>-->
                                 <!--<TextBlock TextWrapping="WrapWholeWords"><Run  Foreground="Gray"  Text="{Binding username}"></Run></TextBlock>-->
                                 <TextBlock Margin="0 2 -4 0" Foreground="{x:Bind Path=UserNameColor,Converter={StaticResource colorConvert}}" Text="{x:Bind UserName}"></TextBlock>
                             </StackPanel>


### PR DESCRIPTION
对于直播右侧弹幕栏, 更新列表:

1. 现在可以拖动宽度
2. 现在可以显示舰长类别并显示相应图片
3. 现在可以显示b站黄豆表情
4. 现在可以显示大表情（应该是任意来源的大表情，需进一步测试）

删除的内容:

1. 现在去除了用户UL等级，因为这个早就被b站弃用/半弃用了，似乎没什么用。
2. 现在去除了用户头衔，（感觉很占地方还不好看就注释掉了……，如果有需求可以直接改回来），因为似乎没什么用。

更正的内容:
现在富文本生成时的去除控制符号的正则表达式优化了一下，使得其不再匹配例如`🤓`的emoji了。

目前存在的问题:

1. 用户单独发送B站黄豆表情没有附带文本时，黄豆的显示位置会不正常的偏上。
2. ~总是感觉有点丑，元素的间距什么的需要优化 还有这个舰长的图片是很多年前的吗~

效果图: 
![image](https://github.com/ywmoyue/biliuwp-lite/assets/82302542/bab39173-2398-4117-b0de-a641699de244)
