### PR TITLE
修复并重新布局了历史记录页面

### DIFF
--- a/src/BiliLite.UWP/Models/Common/User/UserHistoryItem.cs
+++ b/src/BiliLite.UWP/Models/Common/User/UserHistoryItem.cs
@@ -70,6 +70,8 @@ namespace BiliLite.Models.Common.User
         [JsonProperty("tag_name")]
         public string TagName { get; set; }
 
+        public bool ShowTag { get { return TagName.Length > 0; } }
+
         [JsonProperty("live_status")]
         public long LiveStatus { get; set; }
     }

--- a/src/BiliLite.UWP/Models/Common/User/UserHistoryItem.cs
+++ b/src/BiliLite.UWP/Models/Common/User/UserHistoryItem.cs
@@ -70,7 +70,7 @@ namespace BiliLite.Models.Common.User
         [JsonProperty("tag_name")]
         public string TagName { get; set; }
 
-        public bool ShowTag { get { return TagName.Length > 0; } }
+        public bool ShowTag => TagName.Length > 0;
 
         [JsonProperty("live_status")]
         public long LiveStatus { get; set; }

--- a/src/BiliLite.UWP/Modules/User/HistoryVM.cs
+++ b/src/BiliLite.UWP/Modules/User/HistoryVM.cs
@@ -65,6 +65,15 @@ namespace BiliLite.Modules.User
                     }
 
                     Videos = new ObservableCollection<UserHistoryItem>(data.data.List);
+
+                    // 默认封面如果缺失, 用其他封面替换
+                    foreach (var item in Videos)
+                    {
+                        if (item.Cover.Length == 0 && item.Covers != null)
+                        {
+                            item.Cover = (string)((JArray)item.Covers)[0];
+                        }
+                    }
                 }
                 else
                 {

--- a/src/BiliLite.UWP/Pages/User/HistoryPage.xaml
+++ b/src/BiliLite.UWP/Pages/User/HistoryPage.xaml
@@ -3,29 +3,27 @@
     x:Class="BiliLite.Pages.User.HistoryPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:BiliLite.Pages.User"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
-    xmlns:fa="using:FontAwesome5"
     xmlns:controls="using:BiliLite.Controls"
     xmlns:toolkit="using:Microsoft.Toolkit.Uwp.UI.Controls"
     xmlns:convert="using:BiliLite.Converters"
     xmlns:model="using:BiliLite.Modules.User"
-    xmlns:userModel="using:BiliLite.Models.Common.User"
+    xmlns:userModel="using:BiliLite.Models.Common.User" d:DataContext="{d:DesignInstance Type=model:HistoryVM}"
     Background="Transparent">
     <Page.Resources>
         <SolidColorBrush x:Key="PivotHeaderBackground" Color="{ThemeResource TopPaneBackground}"></SolidColorBrush>
         <convert:DatetimeConvert x:Key="datetime"/>
         <Style x:Key="ItemStyle" TargetType="GridViewItem">
-            <Setter Property="Margin" Value="8"></Setter>
+            <Setter Property="Margin" Value="4"></Setter>
             <Setter Property="HorizontalContentAlignment" Value="Stretch"></Setter>
             <Setter Property="VerticalContentAlignment" Value="Stretch"></Setter>
         </Style>
         <DataTemplate x:Key="VideoDataTemplate" x:DataType="userModel:UserHistoryItem">
             <Grid Background="#00FFFFFF">
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="180"/>
                     <ColumnDefinition/>
                 </Grid.ColumnDefinitions>
                 <Grid.ContextFlyout>
@@ -33,19 +31,36 @@
                         <MenuFlyoutItem Text="移除" Click="removeVideoHistory_Click"></MenuFlyoutItem>
                     </MenuFlyout>
                 </Grid.ContextFlyout>
-                <Border CornerRadius="{StaticResource ImageCornerRadius}">
-                    <toolkit:ImageEx IsCacheEnabled="True" Height="80" Width="120" PlaceholderSource="ms-appx:///Assets/Thumbnails/Placeholde.png" Stretch="UniformToFill" Source="{x:Bind Path=Cover,Converter={StaticResource imageConvert},ConverterParameter='160w'}"></toolkit:ImageEx>
+                <Border Grid.Column="0" CornerRadius="{StaticResource ImageCornerRadius}">
+                    <StackPanel>
+                        <toolkit:ImageEx IsCacheEnabled="True" PlaceholderSource="/Assets/Thumbnails/Placeholde.png" Stretch="UniformToFill" Source="{x:Bind Path=Cover,Converter={StaticResource imageConvert},ConverterParameter='180w_100h_1c'}"></toolkit:ImageEx>
+                    </StackPanel>
                 </Border>
-                <StackPanel Grid.Column="1" Margin="8 0 0 0">
-                    <TextBlock MaxLines="2" Margin="0 0 0 4" TextTrimming="CharacterEllipsis" Text="{x:Bind Title}"></TextBlock>
-                    <TextBlock Margin="0 4" FontSize="14" Foreground="Gray" >UP:<Run Text="{x:Bind Path=AuthorName}"/></TextBlock>
-                    <TextBlock Margin="0 4" FontSize="14" Foreground="Gray" Text="{x:Bind Path=ViewAt,Converter={StaticResource datetime},ConverterParameter='ts'}"></TextBlock>
-                </StackPanel>
+                <Grid Grid.Column="1">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    <StackPanel Grid.Row="0" Margin="8 0 0 0" VerticalAlignment="Top">
+                        <TextBlock MaxLines="2" Margin="0 0 0 0" TextTrimming="CharacterEllipsis" Text="{x:Bind Title}" TextWrapping="Wrap"></TextBlock>
+                    </StackPanel>
+                    <StackPanel Grid.Row="1" Margin="8 0 0 0" VerticalAlignment="Bottom">
+                        <TextBlock VerticalAlignment="Bottom" Margin="0 3 0 0" FontSize="13" Foreground="Gray" Text="{x:Bind Path=AuthorName}"></TextBlock>
+                        <TextBlock VerticalAlignment="Bottom" Margin="0 3 0 0" FontSize="13" Foreground="Gray" Visibility="{x:Bind ShowTag}"><Run Text="{x:Bind Path=TagName}"></Run></TextBlock>
+                    </StackPanel>
+                    <StackPanel Grid.Row="2" Margin="8 0 0 0" VerticalAlignment="Bottom">
+                        <TextBlock Margin="0 3 0 0" FontSize="13" Foreground="Gray">
+                             <Run Text="{x:Bind Path=ViewAt,Converter={StaticResource datetime},ConverterParameter='ts'}"></Run>
+                             <Run Text="{x:Bind Path=Badge}"></Run>         
+                        </TextBlock>
+                    </StackPanel>
+                </Grid>
             </Grid>
         </DataTemplate>
     </Page.Resources>
     <Grid>
-        <Pivot >
+        <Pivot>
             <!--<Pivot.RightHeader>
                 <Grid Background="{ThemeResource TopPaneBackground}">
                     <Button Margin="8 0">清空记录</Button>
@@ -56,15 +71,18 @@
                     <TextBlock FontSize="15">视频</TextBlock>
                 </PivotItem.Header>
                 <Grid>
-                    <toolkit:AdaptiveGridView SelectionMode="None" 
-                                          IsItemClickEnabled="True"
-                                          DesiredWidth="600"
-                                          ItemClick="Video_ItemClick"
-                                          StretchContentForSingleRow="False"
-                                          ItemContainerStyle="{StaticResource ItemStyle}"
-                                          ItemTemplate="{StaticResource VideoDataTemplate}"
-                                          ItemsSource="{x:Bind Path=historyVM.Videos,Mode=OneWay}"
-                                          ItemHeight="80" Grid.ColumnSpan="2">
+                    <toolkit:AdaptiveGridView 
+                        SelectionMode="None"
+                        Padding="12 8"
+                        IsItemClickEnabled="True"
+                        DesiredWidth="600"
+                        ItemClick="Video_ItemClick"
+                        StretchContentForSingleRow="False"
+                        ItemContainerStyle="{StaticResource ItemStyle}"
+                        ItemTemplate="{StaticResource VideoDataTemplate}"
+                        ItemsSource="{x:Bind Path=historyVM.Videos,Mode=OneWay}"
+                        ItemHeight="100" 
+                        Grid.ColumnSpan="2">
 
                         <toolkit:AdaptiveGridView.Footer>
                             <StackPanel>

--- a/src/BiliLite.UWP/Pages/User/HistoryPage.xaml.cs
+++ b/src/BiliLite.UWP/Pages/User/HistoryPage.xaml.cs
@@ -34,6 +34,7 @@ namespace BiliLite.Pages.User
         private void Video_ItemClick(object sender, ItemClickEventArgs e)
         {
             var data = e.ClickedItem as UserHistoryItem;
+            // TODO: 改用方法Map
             if(data.History.Business == "pgc")
             {
                 MessageCenter.NavigateToPage(this, new NavigationInfo()

--- a/src/BiliLite.UWP/Pages/User/HistoryPage.xaml.cs
+++ b/src/BiliLite.UWP/Pages/User/HistoryPage.xaml.cs
@@ -34,7 +34,7 @@ namespace BiliLite.Pages.User
         private void Video_ItemClick(object sender, ItemClickEventArgs e)
         {
             var data = e.ClickedItem as UserHistoryItem;
-            if(data.History.Business== "pgc")
+            if(data.History.Business == "pgc")
             {
                 MessageCenter.NavigateToPage(this, new NavigationInfo()
                 {
@@ -42,6 +42,46 @@ namespace BiliLite.Pages.User
                     page = typeof(SeasonDetailPage),
                     title = data.Title,
                     parameters = data.Kid
+                });
+            } 
+            else if (data.History.Business == "live") // 直播
+            {
+                MessageCenter.NavigateToPage(this, new NavigationInfo()
+                {
+                    icon= Symbol.Play,
+                    page = typeof(LiveDetailPage),
+                    title = data.Title,
+                    parameters = data.History.Oid
+                });
+            }
+            else if (data.History.Business == "archive") // 普通视频
+            {
+                MessageCenter.NavigateToPage(this, new NavigationInfo()
+                {
+                    icon = Symbol.Play,
+                    page = typeof(VideoDetailPage),
+                    title = data.Title,
+                    parameters = data.History.Bvid
+                });
+            }
+            else if (data.History.Business == "article") // 专栏
+            {
+                MessageCenter.NavigateToPage(this, new NavigationInfo()
+                {
+                    icon = Symbol.Play,
+                    page = typeof(WebPage), // 专栏好像没有写专门的页面
+                    title = data.Title,
+                    parameters = "https://www.bilibili.com/read/cv" + data.History.Oid
+                });
+            }
+            else if (data.History.Business == "article-list") // 专栏文集, 但历史记录里实际保存的为其中的专栏文章
+            {
+                MessageCenter.NavigateToPage(this, new NavigationInfo()
+                {
+                    icon = Symbol.Play,
+                    page = typeof(WebPage), // 专栏文集好像没有写专门的页面
+                    title = data.Title,
+                    parameters = "https://www.bilibili.com/read/cv" + data.History.Cid
                 });
             }
             else

--- a/src/BiliLite.UWP/ViewModels/Video/VideoDetailPageViewModel.cs
+++ b/src/BiliLite.UWP/ViewModels/Video/VideoDetailPageViewModel.cs
@@ -210,6 +210,7 @@ namespace BiliLite.Modules
         {
             try
             {
+                if (id.Length == 0) { throw new ArgumentException(nameof(id)); } 
                 Loaded = false;
                 Loading = true;
                 ShowError = false;


### PR DESCRIPTION
fix https://github.com/ywmoyue/biliuwp-lite/issues/400#issuecomment-1809850056

修复:

1. 历史记录页面打不开除了普通视频外的内容
2. 历史记录页面有些内容无封面

新增:

1. 历史记录现在有对应的类型和tag显示

更改:

1. 更改了历史记录页面的元素显示，效果如下(参考了看起来效果更好的 直播-关注的直播)：
    
![image](https://github.com/ywmoyue/biliuwp-lite/assets/82302542/fa9282c2-c8e5-497e-b63b-76e314aeb565)
