### PR TITLE
修复某些UP主的动态问题

### DIFF
--- a/src/BiliLite.UWP/Extensions/DynamicParseExtensions.cs
+++ b/src/BiliLite.UWP/Extensions/DynamicParseExtensions.cs
@@ -79,6 +79,10 @@ namespace BiliLite.Extensions
                 //处理换行
                 input = input.Replace("\r\n", "<LineBreak/>");
                 input = input.Replace("\n", "<LineBreak/>");
+
+                //处理其他控制字符
+                input = Regex.Replace(input, @"[\p{Cc}\p{Cf}]", string.Empty);
+
                 //处理@
                 input = HandelAtAndVote(input, txt, extend_json);
                 //处理网页🔗

--- a/src/BiliLite.UWP/Models/Builders/DynamicItemDisplayModelBuilder.cs
+++ b/src/BiliLite.UWP/Models/Builders/DynamicItemDisplayModelBuilder.cs
@@ -134,10 +134,10 @@ namespace BiliLite.Models.Builders
 
                 // TODO: 完全展示转发内容
                 case UserDynamicDisplayType.Text when (extendJson != null && extendJson.ContainsKey("")):
-                    var ugc_id = (string)extendJson[""]?["ugc"]?["ugc_id"];
-                    if (ugc_id != null && ugc_id.Length > 0)
+                    var ugcId = (string)extendJson[""]?["ugc"]?["ugc_id"];
+                    if (!string.IsNullOrEmpty(ugcId))
                     {
-                        card["item"]["content"] += ("\nav" + ugc_id);
+                        card["item"]["content"] += ("\nav" + ugcId);
                     }
                     break;
             }

--- a/src/BiliLite.UWP/Models/Builders/DynamicItemDisplayModelBuilder.cs
+++ b/src/BiliLite.UWP/Models/Builders/DynamicItemDisplayModelBuilder.cs
@@ -49,7 +49,7 @@ namespace BiliLite.Models.Builders
             return this;
         }
 
-        public DynamicItemDisplayModelBuilder SwitchType(IMapper mapper, JObject card)
+        public DynamicItemDisplayModelBuilder SwitchType(IMapper mapper, JObject card, JObject extendJson)
         {
             switch (m_displayViewModel.Type)
             {
@@ -106,7 +106,7 @@ namespace BiliLite.Models.Builders
                             originDisplayView = new DynamicItemDisplayModelBuilder()
                                 .Init(mapper, model, cardOrigin)
                                 .SetCommands(m_displayViewModel.UserDynamicItemDisplayCommands)
-                                .SwitchType(mapper, cardOrigin)
+                                .SwitchType(mapper, cardOrigin, extendJsonOrigin)
                                 .SetCommentCount(cardOrigin)
                                 .SetContent(cardOrigin, extendJsonOrigin)
                                 .SetSeasonInfo(cardOrigin)
@@ -130,6 +130,15 @@ namespace BiliLite.Models.Builders
                                 Type= UserDynamicDisplayType.Miss
                             }
                         };
+                    break;
+
+                // TODO: 完全展示转发内容
+                case UserDynamicDisplayType.Text when (extendJson != null && extendJson.ContainsKey("")):
+                    var ugc_id = (string)extendJson[""]?["ugc"]?["ugc_id"];
+                    if (ugc_id != null && ugc_id.Length > 0)
+                    {
+                        card["item"]["content"] += ("\nav" + ugc_id);
+                    }
                     break;
             }
 

--- a/src/BiliLite.UWP/Models/Common/Comment/CommentMemberUserSailingPendantModel.cs
+++ b/src/BiliLite.UWP/Models/Common/Comment/CommentMemberUserSailingPendantModel.cs
@@ -2,7 +2,7 @@
 {
     public class CommentMemberUserSailingPendantModel
     {
-        public int Id { get; set; }
+        public long Id { get; set; }
 
         public string Name { get; set; }
 

--- a/src/BiliLite.UWP/ViewModels/UserDynamic/UserDynamicViewModel.cs
+++ b/src/BiliLite.UWP/ViewModels/UserDynamic/UserDynamicViewModel.cs
@@ -350,7 +350,7 @@ namespace BiliLite.ViewModels.UserDynamic
                         DetailCommand = DetailCommand,
                         WatchLaterCommand = m_watchLaterVm.AddCommand,
                     })
-                    .SwitchType(m_mapper, card)
+                    .SwitchType(m_mapper, card, extendJson)
                     .SetCommentCount(card)
                     .SetContent(card, extendJson)
                     .SetSeasonInfo(card)


### PR DESCRIPTION
对于这个UP的动态: https://space.bilibili.com/13030523/dynamic
修复以下问题: 

1. 修复其转发视频只有文字的问题。
    这个问题是由于该UP主所用的转发方式和其他人不同导致的。（我没找到怎么使用这种方式）
    且由于本项目所用的获取动态的api:`api.vc.bilibili.com`获取的信息不足 (如例子中, `extendJson`仅有转发的视频的av号) : 
    ```
    "": {
      "ugc": {
        "ugc_id": 4772741
      }
    }"
    ```
    所以修复方法就是给这类型的动态加个其转发的av号.
    ~（其实也有其他办法，比如直接用此av号获取视频信息再填充回卡片，就是有点……还不如直接更换现在网页端使用的`api.bilibili.com`）~

2. 修复其某个动态评论区无法加载的问题
    `https://t.bilibili.com/861441728029130790` 
    此评论区中某个用户的挂件(?)的id 过长，超过了Int32,产生以下错误，改成Long后正常：
    ```
    |ERROR|3|CommentControl.GetComment|JSON integer 1699850526001 is too large or small for an Int32. Path 'data.replies[10].member.user_sailing.pendant.id', line 1, position 51007.|JSON integer 1699850526001 is too large or small for an Int32. Path 'data.replies[10].member.user_sailing.pendant.id', line 1, position 51007. 
    ```
    实际上这个值并未使用，以后如果要应对更长的id的话直接使用string吧。

3. 潜在隐患修复：评论的转富文本方法未去除多余的控制字符，可能会导致xaml生成故障。
    使用前几个commit的方法修复。

建议：以后有可能的话，将获取动态的api改为现在网页端使用的`api.bilibili.com`, 以获取更大的兼容性, 保证动态的正常显示(而且这个的文档在隔壁API-Collect也更多)