### PR TITLE
修复二维码登录下无播放列表的问题

### DIFF
--- a/src/BiliLite.UWP/Models/Common/Video/VideoUgcSeasonSectionEpisode.cs
+++ b/src/BiliLite.UWP/Models/Common/Video/VideoUgcSeasonSectionEpisode.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using BiliLite.Models.Common.Video.Detail;
+using Newtonsoft.Json;
 
 namespace BiliLite.Models.Common.Video
 {
@@ -12,7 +13,12 @@ namespace BiliLite.Models.Common.Video
 
         public string Title { get; set; }
 
-        public string Cover { get; set; }
+        private string _cover;
+        public string Cover
+        {
+            get => _cover ?? Arc.Pic;
+            set => _cover = value;
+        }
 
         [JsonProperty("cover_right_text")]
         public string CovverRightText { get; set; }
@@ -34,5 +40,8 @@ namespace BiliLite.Models.Common.Video
 
         [JsonProperty("first_frame")]
         public string FirstFrame { get; set; }
+
+        [JsonProperty("arc")]
+        public VideoDetailModel Arc { get; set; } // 简单复用一下
     }
 }

--- a/src/BiliLite.UWP/Models/Common/Video/VideoUgcSeasonSectionEpisode.cs
+++ b/src/BiliLite.UWP/Models/Common/Video/VideoUgcSeasonSectionEpisode.cs
@@ -5,6 +5,8 @@ namespace BiliLite.Models.Common.Video
 {
     public class VideoUgcSeasonSectionEpisode
     {
+        private string m_cover;
+
         public long Id { get; set; }
 
         public string Aid { get; set; }
@@ -13,11 +15,10 @@ namespace BiliLite.Models.Common.Video
 
         public string Title { get; set; }
 
-        private string _cover;
         public string Cover
         {
-            get => _cover ?? Arc.Pic;
-            set => _cover = value;
+            get => m_cover ?? Arc.Pic;
+            set => m_cover = value;
         }
 
         [JsonProperty("cover_right_text")]

--- a/src/BiliLite.UWP/Pages/VideoDetailPage.xaml
+++ b/src/BiliLite.UWP/Pages/VideoDetailPage.xaml
@@ -38,11 +38,9 @@
                             <Grid>
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition />
+                                    <ColumnDefinition Width="*" />
                                 </Grid.ColumnDefinitions>
-                                <Border CornerRadius="2">
-                                    <Image Width="100" Source="{Binding Cover}"></Image>
-                                </Border>
+                                <Image Grid.Column="0" HorizontalAlignment="Left" Width="140" Source="{Binding Cover,Converter={StaticResource imageConvert},ConverterParameter='140w'}"></Image>
 
                                 <StackPanel Grid.Column="1" Margin="8 0 0 0">
                                     <TextBlock TextWrapping="Wrap" MaxLines="2" TextTrimming="CharacterEllipsis" Text="{Binding Title}"></TextBlock>
@@ -53,8 +51,7 @@
                     </ListView.ItemTemplate>
                     <ListView.ItemContainerStyle>
                         <Style TargetType="ListViewItem">
-                            <Setter Property="Padding" Value="4"></Setter>
-                            <Setter Property="Margin" Value="8 4"></Setter>
+                            <Setter Property="Margin" Value="0 4 0 0"></Setter>
                         </Style>
                     </ListView.ItemContainerStyle>
                   

--- a/src/BiliLite.UWP/ViewModels/Video/VideoDetailPageViewModel.cs
+++ b/src/BiliLite.UWP/ViewModels/Video/VideoDetailPageViewModel.cs
@@ -216,6 +216,7 @@ namespace BiliLite.Modules
                 ShowError = false;
                 var needGetUserReq = false;
                 // 正常app获取视频详情
+                // 暂停使用, 因为二维码登录下会拿不到分集
                 var results = await videoAPI.Detail(id, isbvid).Request();
                 if (!results.status)
                 {
@@ -224,6 +225,7 @@ namespace BiliLite.Modules
 
                 var data = await results.GetJson<ApiDataModel<VideoDetailModel>>();
 
+                // 通过web获取, 作为后备使用
                 if (!data.success)
                 {
                     // 通过web获取视频详情
@@ -250,6 +252,21 @@ namespace BiliLite.Modules
                 if (!data.success)
                 {
                     throw new CustomizedErrorException(data.message);
+                }
+
+                var webResults = await videoAPI.DetailWebInterface(id, isbvid).Request();
+                if (!webResults.status)
+                {
+                    throw new CustomizedErrorException(webResults.message);
+                }
+                var webData = await webResults.GetJson<ApiDataModel<VideoDetailModel>>();
+                if (!webData.success)
+                {
+                    throw new CustomizedErrorException(webData.message);
+                }
+                if (data.data.UgcSeason == null && webData.data.UgcSeason != null)
+                {
+                    data.data.UgcSeason = webData.data.UgcSeason;
                 }
 
                 var videoInfoViewModel = m_mapper.Map<VideoDetailViewModel>(data.data);

--- a/src/BiliLite.UWP/ViewModels/Video/VideoDetailPageViewModel.cs
+++ b/src/BiliLite.UWP/ViewModels/Video/VideoDetailPageViewModel.cs
@@ -216,7 +216,6 @@ namespace BiliLite.Modules
                 ShowError = false;
                 var needGetUserReq = false;
                 // 正常app获取视频详情
-                // 暂停使用, 因为二维码登录下会拿不到分集
                 var results = await videoAPI.Detail(id, isbvid).Request();
                 if (!results.status)
                 {


### PR DESCRIPTION
fix #419 
本问题主要是因为在二维码登录的情况下，视频详情的api `https://app.bilibili.com/x/v2/view` 拿到的`ugc_season`为`null`导致的。 
暂时不知道是b站官方的api弃用还是什么问题。
使用了web版的api数据填充了，目前除了播放列表除了没有每集的作者名称（感觉并不太重要）外是可用的。

目前我使用ipad抓包, app端的视频详情api已经换成了grpc `/bilibili.app.view.v1.View/View`. 如果您有时间的话还是希望给这里换成grpc! @ywmoyue 