### PR TITLE
直播间bug修复以及新增默认直播流选择

### DIFF
--- a/src/BiliLite.UWP/BiliLite.UWP.csproj
+++ b/src/BiliLite.UWP/BiliLite.UWP.csproj
@@ -26,7 +26,7 @@
     <AppxBundle>Never</AppxBundle>
     <AppxBundlePlatforms>x64</AppxBundlePlatforms>
     <HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
-    <PackageCertificateThumbprint>1390A579B0B0B21AE8AAEFB9D5A141141F9A1D16</PackageCertificateThumbprint>
+    <PackageCertificateThumbprint>C4FA34A878A0528F84922932FEC6746BCBCA5CEA</PackageCertificateThumbprint>
     <PackageCertificateKeyFile />
     <AppxSymbolPackageEnabled>False</AppxSymbolPackageEnabled>
   </PropertyGroup>

--- a/src/BiliLite.UWP/BiliLite.UWP.csproj
+++ b/src/BiliLite.UWP/BiliLite.UWP.csproj
@@ -26,7 +26,7 @@
     <AppxBundle>Never</AppxBundle>
     <AppxBundlePlatforms>x64</AppxBundlePlatforms>
     <HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
-    <PackageCertificateThumbprint>C4FA34A878A0528F84922932FEC6746BCBCA5CEA</PackageCertificateThumbprint>
+    <PackageCertificateThumbprint>1390A579B0B0B21AE8AAEFB9D5A141141F9A1D16</PackageCertificateThumbprint>
     <PackageCertificateKeyFile />
     <AppxSymbolPackageEnabled>False</AppxSymbolPackageEnabled>
   </PropertyGroup>
@@ -138,6 +138,7 @@
   <ItemGroup>
     <Compile Include="Extensions\QrCodeExtensions.cs" />
     <Compile Include="Models\Common\Anime\ISeasonItem.cs" />
+    <Compile Include="Models\Common\Live\DefaultPlayUrlSourceOptions.cs" />
     <Compile Include="Models\Common\Live\InteractWordModel.cs" />
     <Compile Include="Models\Common\Live\LiveMessageHandleActionsMap.cs" />
     <Compile Include="Models\Common\Live\LiveRoomEndRedPocketLotteryInfoModel.cs" />
@@ -801,6 +802,7 @@
     <Content Include="Assets\Live\ic_live_guard_2.png" />
     <Content Include="Assets\Live\ic_live_guard_3.png" />
     <Content Include="Assets\Live\lottery.png" />
+    <Content Include="Assets\Live\RedPocket.png" />
     <Content Include="Assets\LockScreenLogo.scale-200.png" />
     <Content Include="Assets\Login\ic_22.png" />
     <Content Include="Assets\Login\ic_22_hide.png" />

--- a/src/BiliLite.UWP/Models/Common/Live/DefaultPlayUrlSourceOptions.cs
+++ b/src/BiliLite.UWP/Models/Common/Live/DefaultPlayUrlSourceOptions.cs
@@ -1,0 +1,21 @@
+﻿namespace BiliLite.Models.Common.Live
+{
+    public static class DefaultPlayUrlSourceOptions
+    {
+        public static LivePlayUrlSourceOption[] DefaultLivePlayUrlSourceOption = new LivePlayUrlSourceOption[]
+        {
+            new LivePlayUrlSourceOption() { Name = "京东云MCDN(PCDN?)", Value = "mcdn" },
+            new LivePlayUrlSourceOption() { Name = "B站自建地区CDN", Value = "cn-"},
+            new LivePlayUrlSourceOption() { Name = "备用及第三方CDN", Value = "-gotcha"},
+        };
+
+        public const string DEFAULT_PLAY_URL_SOURCE = "cn-"; //默认使用B站自建CDN
+    }
+
+    public class LivePlayUrlSourceOption
+    {
+        public string Name { get; set; }
+
+        public string Value { get; set; }
+    }
+}

--- a/src/BiliLite.UWP/Models/Common/Live/LiveMessageHandleActionsMap.cs
+++ b/src/BiliLite.UWP/Models/Common/Live/LiveMessageHandleActionsMap.cs
@@ -140,7 +140,6 @@ namespace BiliLite.Models.Common.Live
             if (!viewModel.ReceiveLotteryMsg) return;
             var info = message.ToString();
             viewModel.LotteryViewModel.SetAnchorLotteryInfo(JsonConvert.DeserializeObject<LiveRoomAnchorLotteryInfoModel>(info));
-            
         }
 
         private void RedPocketLotteryStart(LiveRoomViewModel viewModel, object message) 
@@ -225,7 +224,7 @@ namespace BiliLite.Models.Common.Live
 
         private async void StartLive(LiveRoomViewModel viewModel, object room_Id)
         {
-            await System.Threading.Tasks.Task.Delay(TimeSpan.FromSeconds(3)); // 挂起三秒再获取, 否则很大可能一直卡加载而不缓冲
+            await System.Threading.Tasks.Task.Delay(TimeSpan.FromSeconds(5)); // 挂起五秒再获取, 否则很大可能一直卡加载而不缓冲
             viewModel.GetPlayUrls(room_Id.ToInt32(), SettingService.GetValue(SettingConstants.Live.DEFAULT_QUALITY, 10000)).RunWithoutAwait();
             viewModel.Messages.Add(new DanmuMsgModel()
             {

--- a/src/BiliLite.UWP/Models/Common/SettingConstants.cs
+++ b/src/BiliLite.UWP/Models/Common/SettingConstants.cs
@@ -343,6 +343,11 @@ namespace BiliLite.Models.Common
             /// 隐藏抽奖
             /// </summary>
             public const string HIDE_LOTTERY = "LiveHideLottery";
+
+            /// <summary>
+            /// 直播流默认源
+            /// </summary>
+            public const string DEFAULT_LIVE_PLAY_URL_SOURCE = "DefaultLivePlayUrlSource";
         }
 
         public class Player

--- a/src/BiliLite.UWP/Pages/LiveDetailPage.xaml
+++ b/src/BiliLite.UWP/Pages/LiveDetailPage.xaml
@@ -433,14 +433,28 @@
                                                             <Slider x:Name="LiveSettingCount" Width="240" Minimum="50" Maximum="1000" StepFrequency="1"></Slider>
                                                             <ToggleSwitch x:Name="LiveSettingAutoOpenBox" Visibility="Collapsed" Margin="0 8 0 0" Header="自动开启宝箱"></ToggleSwitch>
                                                             <ToggleSwitch x:Name="LiveSettingHardwareDecode" Margin="0 8 0 0" Header="开启硬解"></ToggleSwitch>
-                                                            <TextBlock Margin="0 4">播放器默认模式</TextBlock>
-                                                            <ComboBox  x:Name="PlayerModeComboBox"  MinWidth="200"
-                                                                       ItemsSource="{x:Bind Player:DefaultPlayerModeOptions.DefaultLivePlayerModeOption}" 
-                                                                       SelectedValue="{x:Bind m_viewModel.LivePlayerMode, Mode=TwoWay}"
-                                                                       SelectionChanged="PlayerModeComboBox_OnSelectionChanged"
-                                                                       SelectedValuePath="Value"
-                                                                       DisplayMemberPath="Name">
-                                                            </ComboBox>
+                                                            <StackPanel Margin="0 8 0 0">
+                                                                <TextBlock Margin="0 4 0 0">播放器默认模式</TextBlock>
+                                                                <ComboBox  x:Name="PlayerModeComboBox"  MinWidth="200"
+                                                                    ItemsSource="{x:Bind Player:DefaultPlayerModeOptions.DefaultLivePlayerModeOption}" 
+                                                                    SelectedValue="{x:Bind m_viewModel.LivePlayerMode, Mode=TwoWay}"
+                                                                    SelectionChanged="PlayerModeComboBox_OnSelectionChanged"
+                                                                    SelectedValuePath="Value"
+                                                                    DisplayMemberPath="Name"
+                                                                    Margin="0 4 0 0">                
+                                                                </ComboBox>
+                                                            </StackPanel>
+                                                            <StackPanel Margin="0 8 0 0">
+                                                                <TextBlock Margin="0 4 0 0">直播流默认来源</TextBlock>
+                                                                <ComboBox x:Name="PlayUrlSourceComboBox" MinWidth="200" 
+                                                                    ItemsSource="{x:Bind live:DefaultPlayUrlSourceOptions.DefaultLivePlayUrlSourceOption}"      
+                                                                    SelectedValue="{x:Bind m_viewModel.LivePlayUrlSource, Mode=TwoWay}"
+                                                                    SelectionChanged="PlayUrlSourceComboBox_OnSelectionChanged"
+                                                                    SelectedValuePath="Value"
+                                                                    DisplayMemberPath="Name"      
+                                                                    Margin="0 4 0 0">
+                                                                </ComboBox>
+                                                            </StackPanel>
                                                         </StackPanel>
                                                     </PivotItem>
                                                     <PivotItem>
@@ -750,7 +764,7 @@
                                         <TextBlock Margin="0 4" TextWrapping="Wrap"><Run Foreground="Gray">弹幕口令：</Run><Run Text="{x:Bind Path=m_liveRoomViewModel.LotteryViewModel.AnchorLotteryInfo.Danmu,Mode=OneWay}"/></TextBlock>
                                         <TextBlock Margin="0 4" TextWrapping="Wrap" Visibility="{x:Bind Path=m_liveRoomViewModel.LotteryViewModel.AnchorLotteryInfo.ShowGift,Mode=OneWay}"><Run Foreground="Gray">赠送礼物：</Run><Run Text="{x:Bind Path=m_liveRoomViewModel.LotteryViewModel.AnchorLotteryInfo.GiftName,Mode=OneWay}"/>x<Run Text="{x:Bind Path=m_liveRoomViewModel.LotteryViewModel.AnchorLotteryInfo.GiftNum,Mode=OneWay}"/></TextBlock>
                                         <TextBlock Margin="0 4" TextWrapping="Wrap"><Run Foreground="Gray">限制条件：</Run><Run Text="{x:Bind Path=m_liveRoomViewModel.LotteryViewModel.AnchorLotteryInfo.RequireText,Mode=OneWay}"/></TextBlock>-->
-                                        <Button x:Name="BtnSendLotteryDanmu" Click="BtnSendLotteryDanmu_Click" Margin="0 4 0 0" HorizontalAlignment="Stretch">一键发弹幕</Button>
+                                        <Button x:Name="BtnSendLotteryDanmu" Visibility="{x:Bind Path=m_liveRoomViewModel.ShowAnchorLotteryWinnerList,Mode=OneWay,Converter={StaticResource display}}" Click="BtnSendLotteryDanmu_Click" Margin="0 4 0 0" HorizontalAlignment="Stretch">一键发弹幕</Button>
                                     </StackPanel>
                                 </Flyout>
                             </Button.Flyout>
@@ -848,7 +862,7 @@
                             </Button.Flyout>
                         </Button>
                     </StackPanel>
-                    <Grid  HorizontalAlignment="Right" Grid.Column="1">
+                    <Grid  HorizontalAlignment="Right" Grid.Column="1" Margin="10 0 0 0">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto"/>
                            
@@ -856,7 +870,7 @@
                             <ColumnDefinition Width="Auto"/>
                             <ColumnDefinition Width="Auto"/>
                         </Grid.ColumnDefinitions>
-                        <StackPanel Margin="4" VerticalAlignment="Center" Visibility="{x:Bind Path=m_liveRoomViewModel.Logined,Mode=OneWay}">
+                        <StackPanel Grid.Column="0" Margin="4" VerticalAlignment="Center" Visibility="{x:Bind Path=m_liveRoomViewModel.Logined,Mode=OneWay}">
                             <StackPanel Orientation="Horizontal">
                                 <Image Width="16" Source="ms-appx:///Assets/Icon/ic_live_center_silver_recharge.png"></Image>
                                 <TextBlock FontSize="12" Margin="8 0" VerticalAlignment="Center" Text="{x:Bind Path=m_liveRoomViewModel.WalletInfo.Silver,Converter={StaticResource numberToStringConvert},Mode=OneWay}"></TextBlock>

--- a/src/BiliLite.UWP/Pages/LiveDetailPage.xaml.cs
+++ b/src/BiliLite.UWP/Pages/LiveDetailPage.xaml.cs
@@ -132,10 +132,7 @@ namespace BiliLite.Pages
         private void LiveRoomViewModelAnchorLotteryStart(object sender, LiveRoomAnchorLotteryInfoModel e)
         {
             AnchorLotteryWinnerList.Content = e.WinnerList;
-            if (e.WinnerList.Children.Count != 0)
-            {
-                m_liveRoomViewModel.ShowAnchorLotteryWinnerList = true;
-            }
+            m_liveRoomViewModel.ShowAnchorLotteryWinnerList = e.AwardUsers.Count > 0;
         }
 
         private void LiveRoomViewModelAnchorLotteryEnd(object sender, LiveRoomEndAnchorLotteryInfoModel e)
@@ -373,8 +370,24 @@ namespace BiliLite.Pages
 
             m_realPlayInfo.PlayUrls.HlsUrls = m_liveRoomViewModel.HlsUrls;
             m_realPlayInfo.PlayUrls.FlvUrls = m_liveRoomViewModel.FlvUrls;
-            BottomCBLine.ItemsSource = m_liveRoomViewModel.HlsUrls ?? m_liveRoomViewModel.FlvUrls;
-            BottomCBLine.SelectedIndex = 0;
+            var urls = m_liveRoomViewModel.HlsUrls ?? m_liveRoomViewModel.FlvUrls;
+            BottomCBLine.ItemsSource = urls;
+
+            var flag = false;
+            for (var i = 0; i < urls.Count; i++)
+            {
+                var domain = new Uri(urls[i].Url).Host;
+
+                if (domain.Contains(m_viewModel.LivePlayUrlSource) && !flag) {
+                    BottomCBLine.SelectedIndex = i;
+                    flag = true;
+                }
+            }
+            if (!flag)
+            {
+                BottomCBLine.SelectedIndex = 0;
+            }
+
             BottomCBQuality.SelectedItem = m_liveRoomViewModel.CurrentQn;
             changePlayUrlFlag = false;
         }
@@ -511,6 +524,11 @@ namespace BiliLite.Pages
                         SettingConstants.Player.DEFAULT_LIVE_PLAYER_MODE,
                         (int)DefaultPlayerModeOptions.DEFAULT_LIVE_PLAYER_MODE);
             m_playerConfig.PlayMode = m_viewModel.LivePlayerMode;
+
+            // 直播流默认源
+            m_viewModel.LivePlayUrlSource = SettingService.GetValue(
+                SettingConstants.Live.DEFAULT_LIVE_PLAY_URL_SOURCE,
+                DefaultPlayUrlSourceOptions.DEFAULT_PLAY_URL_SOURCE);
         }
 
         private void LoadSetting()
@@ -1203,6 +1221,13 @@ namespace BiliLite.Pages
         {
             SettingService.SetValue(SettingConstants.Player.DEFAULT_LIVE_PLAYER_MODE, m_viewModel.LivePlayerMode);
             m_playerConfig.PlayMode = m_viewModel.LivePlayerMode;
+            await LoadPlayer();
+        }
+
+        private async void PlayUrlSourceComboBox_OnSelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            SettingService.SetValue(SettingConstants.Live.DEFAULT_LIVE_PLAY_URL_SOURCE, m_viewModel.LivePlayUrlSource);
+            LiveRoomViewModelChangedPlayUrl(null, null);
             await LoadPlayer();
         }
     }

--- a/src/BiliLite.UWP/ViewModels/Live/LiveDetailPageViewModel.cs
+++ b/src/BiliLite.UWP/ViewModels/Live/LiveDetailPageViewModel.cs
@@ -78,5 +78,7 @@ namespace BiliLite.ViewModels.Live
                 : new Thickness(0);
 
         public LivePlayerMode LivePlayerMode { get; set; }
+
+        public string LivePlayUrlSource { get; set; }
     }
 }

--- a/src/BiliLite.UWP/ViewModels/Live/LiveRoomLotteryViewModel.cs
+++ b/src/BiliLite.UWP/ViewModels/Live/LiveRoomLotteryViewModel.cs
@@ -83,6 +83,7 @@ namespace BiliLite.ViewModels.Live
                     AnchorLotteryTimer.Stop();
                     AnchorLotteryShow = false;
                     AnchorLotteryInfo = null;
+                    AnchorLotteryDownTime = "--:--";
                     return;
                 }
                 
@@ -116,6 +117,7 @@ namespace BiliLite.ViewModels.Live
                     RedPocketLotteryInfo = null;
                     RedPocketLotteryTimer.Stop();
                     RedPocketLotteryShow = false;
+                    RedPocketLotteryDownTime = "--:--";
                     return;
                 }
 
@@ -175,6 +177,7 @@ namespace BiliLite.ViewModels.Live
         public void SetAnchorLotteryInfo(LiveRoomAnchorLotteryInfoModel info)
         {
             AnchorLotteryInfo = info;
+            AnchorLotteryStart?.Invoke(this, AnchorLotteryInfo);
             AnchorLotteryShow = true;
             AnchorLotteryTimer.Start();
         }


### PR DESCRIPTION
1. 修复天选时刻错误的展示`发送弹幕`按钮和`中奖名单`的问题
2. 修复新一轮天选时刻/人气红包开始时倒计时展示的问题
3. 修复人气红包图片没有正确的被加入csproj的问题
4. 更改了一下金银瓜子的显示位置
5. 新增默认直播流选择
    目前我这里遇到的有三种： 

    - mcdn,疑似来自京东云的pcdn
    - b站自建cdn,基本在每个省份都有服务器
    - 第三方和备用cdn,主要用于海外和备用
    
    其中, b站默认的mcdn在我这里及其不稳定，时不时就会卡住，换用其他源后有好转。
    故此加入了用简单的字符串匹配选择默认直播流的功能。
    但是，在同一界面下的两个ComboBox`播放器默认模式`和`直播流默认来源`还是会有显示bug,目前未找到修复方法。