### PR TITLE
为个人主页添加了合集选项.

### DIFF
--- a/src/BiliLite.UWP/BiliLite.UWP.csproj
+++ b/src/BiliLite.UWP/BiliLite.UWP.csproj
@@ -26,7 +26,7 @@
     <AppxBundle>Never</AppxBundle>
     <AppxBundlePlatforms>x64</AppxBundlePlatforms>
     <HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
-    <PackageCertificateThumbprint>C4FA34A878A0528F84922932FEC6746BCBCA5CEA</PackageCertificateThumbprint>
+    <PackageCertificateThumbprint>1390A579B0B0B21AE8AAEFB9D5A141141F9A1D16</PackageCertificateThumbprint>
     <PackageCertificateKeyFile />
     <AppxSymbolPackageEnabled>False</AppxSymbolPackageEnabled>
   </PropertyGroup>
@@ -183,6 +183,7 @@
     <Compile Include="Models\Common\Live\GiftMsgModel.cs" />
     <Compile Include="Models\Common\Live\GuardBuyMsgModel.cs" />
     <Compile Include="Models\Common\Live\RoomChangeMsgModel.cs" />
+    <Compile Include="Models\Common\User\SubmitCollectionItemModel.cs" />
     <Compile Include="Models\Common\WbiKey.cs" />
     <Compile Include="Models\Exceptions\PlayerException.cs" />
     <Compile Include="Models\Requests\Api\BaseApi.cs" />
@@ -353,6 +354,7 @@
     <Compile Include="ViewModels\Season\SeasonDetailUserStatusViewModel.cs" />
     <Compile Include="ViewModels\Comment\CommentContentViewModel.cs" />
     <Compile Include="ViewModels\Season\SeasonDetailViewModel.cs" />
+    <Compile Include="ViewModels\User\UserSubmitCollectionViewModel.cs" />
     <Compile Include="ViewModels\Video\DanmakuViewModel.cs" />
     <Compile Include="ViewModels\Video\VideoDetailReqUserViewModel.cs" />
     <Compile Include="ViewModels\Video\VideoDetailRelatesViewModel.cs" />

--- a/src/BiliLite.UWP/BiliLite.UWP.csproj
+++ b/src/BiliLite.UWP/BiliLite.UWP.csproj
@@ -26,7 +26,7 @@
     <AppxBundle>Never</AppxBundle>
     <AppxBundlePlatforms>x64</AppxBundlePlatforms>
     <HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
-    <PackageCertificateThumbprint>1390A579B0B0B21AE8AAEFB9D5A141141F9A1D16</PackageCertificateThumbprint>
+    <PackageCertificateThumbprint>C4FA34A878A0528F84922932FEC6746BCBCA5CEA</PackageCertificateThumbprint>
     <PackageCertificateKeyFile />
     <AppxSymbolPackageEnabled>False</AppxSymbolPackageEnabled>
   </PropertyGroup>

--- a/src/BiliLite.UWP/Extensions/ViewModelExtensions.cs
+++ b/src/BiliLite.UWP/Extensions/ViewModelExtensions.cs
@@ -14,6 +14,7 @@ namespace BiliLite.Extensions
             services.AddTransient<DownloadDialogViewModel>();
             services.AddTransient<CommentControlViewModel>();
             services.AddTransient<UserSubmitVideoViewModel>();
+            services.AddTransient<UserSubmitCollectionViewModel>();
             services.AddTransient<RecommendPageViewModel>();
             services.AddTransient<DynamicPageViewModel>();
             services.AddTransient<AnimePageViewModel>();

--- a/src/BiliLite.UWP/Models/Common/User/SubmitCollectionItemModel.cs
+++ b/src/BiliLite.UWP/Models/Common/User/SubmitCollectionItemModel.cs
@@ -1,0 +1,59 @@
+﻿using Newtonsoft.Json;
+
+namespace BiliLite.Models.Common.User
+{
+    public class SubmitCollectionItemModel
+    {
+        /// <summary>
+        /// 本合集的视频数量
+        /// </summary>
+        public int Count { get; set; }
+
+        /// <summary>
+        /// 本合集的封面
+        /// </summary>
+        public string Cover { get; set; }
+
+        /// <summary>
+        /// 跳转格式? 常见值: av
+        /// </summary>
+        public string Goto { get; set; }
+
+        /// <summary>
+        /// 可能是收费视频合集?
+        /// </summary>
+        [JsonProperty("is_pay")]
+        public bool IsPay { get; set; }
+
+        /// <summary>
+        /// 合集最后更新时间戳
+        /// </summary>
+        [JsonProperty("mtime")]
+        public int LatestUpdateTime { get; set; }
+
+        /// <summary>
+        /// 未知参数
+        /// 对于直播回放列表为其纯数字列表id.
+        /// </summary>
+        public string Param { get; set; }
+
+        /// <summary>
+        /// 合集标题
+        /// </summary>
+        public string Title { get; set; }
+
+        /// <summary>
+        /// 合集类型
+        /// 目前发现用户自己创建的为season, 直播回放列表为series
+        /// </summary>
+        public string Type { get; set; }
+
+        /// <summary>
+        /// 跳转链接
+        /// 以bilibili://开头.
+        /// 对于直播回放, 其特别的, 为: bilibili://music/playlist/playpage/{Id}
+        /// Id可能为合集的纯数字id.
+        /// </summary>
+        public string Uri { get; set; }
+    }
+}

--- a/src/BiliLite.UWP/Models/Requests/Api/User/UserDetailAPI.cs
+++ b/src/BiliLite.UWP/Models/Requests/Api/User/UserDetailAPI.cs
@@ -105,13 +105,13 @@ namespace BiliLite.Models.Requests.Api.User
             return api;
         }
 
-        public ApiModel SubmitCollections(string mid, int page_num)
+        public ApiModel SubmitCollections(string mid, int pageNum)
         {
             var api = new ApiModel()
             {
                 method = RestSharp.Method.Get,
                 baseUrl = $"https://app.bilibili.com/x/polymer/space/seasons_series_list_mobile",
-                parameter = $"{ApiHelper.MustParameter(AppKey, true)}&mid={mid}&page_num={page_num}&page_size=20",
+                parameter = $"{ApiHelper.MustParameter(AppKey, true)}&mid={mid}&page_num={pageNum}&page_size=20",
             };
             api.parameter += ApiHelper.GetSign(api.parameter, AppKey);
             return api;

--- a/src/BiliLite.UWP/Models/Requests/Api/User/UserDetailAPI.cs
+++ b/src/BiliLite.UWP/Models/Requests/Api/User/UserDetailAPI.cs
@@ -104,6 +104,19 @@ namespace BiliLite.Models.Requests.Api.User
             };
             return api;
         }
+
+        public ApiModel SubmitCollections(string mid, int page_num)
+        {
+            var api = new ApiModel()
+            {
+                method = RestSharp.Method.Get,
+                baseUrl = $"https://app.bilibili.com/x/polymer/space/seasons_series_list_mobile",
+                parameter = $"{ApiHelper.MustParameter(AppKey, true)}&mid={mid}&page_num={page_num}&page_size=20",
+            };
+            api.parameter += ApiHelper.GetSign(api.parameter, AppKey);
+            return api;
+        }
+
         /// <summary>
         /// 关注的分组
         /// </summary>

--- a/src/BiliLite.UWP/Modules/User/UserDetail/UserDetailVM.cs
+++ b/src/BiliLite.UWP/Modules/User/UserDetail/UserDetailVM.cs
@@ -120,6 +120,7 @@ namespace BiliLite.Modules.User
                         stat.favourite_count = (data.data["favourite2"]?["count"] ?? 0).ToInt32();
                         stat.follower = data.data["card"]["fans"].ToInt32();
                         stat.following = data.data["card"]["attention"].ToInt32();
+                        stat.CollectionCount = (data.data?["ugc_season"]?["count"] ?? 0).ToInt32() + (data.data?["series"]?["item"].ToArray().Length ?? 0);
                         return stat;
                     }
                     else
@@ -304,6 +305,8 @@ namespace BiliLite.Modules.User
             }
         }
 
+        public int CollectionCount { get; set; }
+        public string Collection { get => CollectionCount > 0 ? " " + CollectionCount.ToCountString() : ""; }
     }
     public class UserCenterInfoModel : IModules
     {

--- a/src/BiliLite.UWP/Pages/UserInfoPage.xaml
+++ b/src/BiliLite.UWP/Pages/UserInfoPage.xaml
@@ -230,12 +230,12 @@
                                                     </MenuFlyout>
                                                 </Grid.ContextFlyout>
                                                 <Grid.ColumnDefinitions>
-                                                    <ColumnDefinition Width="160"/>
+                                                    <ColumnDefinition Width="180"/>
                                                     <ColumnDefinition />
                                                 </Grid.ColumnDefinitions>
                                                 <Border Margin="4" CornerRadius="{StaticResource ImageCornerRadius}">
                                                     <Grid>
-                                                        <toolkit:ImageEx IsCacheEnabled="True" PlaceholderSource="ms-appx:///Assets/Thumbnails/Placeholde.png" Stretch="UniformToFill" Source="{x:Bind Path=Pic,Converter={StaticResource imageConvert},ConverterParameter='120h'}"></toolkit:ImageEx>
+                                                        <toolkit:ImageEx IsCacheEnabled="True" PlaceholderSource="ms-appx:///Assets/Thumbnails/Placeholde.png" Stretch="UniformToFill" Source="{x:Bind Path=Pic,Converter={StaticResource imageConvert},ConverterParameter='360w_200h_1c'}"></toolkit:ImageEx>
                                                         <Border CornerRadius="4" VerticalAlignment="Bottom" HorizontalAlignment="Right" Margin="4" Padding="4 2" Background="#99000000">
                                                             <TextBlock Foreground="White" FontSize="12" Text="{x:Bind Length}"></TextBlock>
                                                         </Border>
@@ -389,11 +389,93 @@
                                 </control:RoundButton>
                             </Grid>
                         </PivotItem>
-                        <!--<PivotItem Margin="0">
+                        <PivotItem Margin="0">
                             <PivotItem.Header>
-                                <TextBlock FontSize="15">频道</TextBlock>
+                                <TextBlock FontSize="15">合集<Run Foreground="Gray" FontSize="12" Text="{x:Bind Path=userDetailVM.UserInfo.stat.Collection,Mode=OneWay}"/></TextBlock>
                             </PivotItem.Header>
-                        </PivotItem>-->
+                            <Grid>
+                                <control:MyAdaptiveGridView
+                                    Padding="12 8" 
+                                    ItemHeight="100" 
+                                    DesiredWidth="600" 
+                                    StretchContentForSingleRow="False" 
+                                    SelectionMode="None" 
+                                    IsItemClickEnabled="True" 
+                                    CanLoadMore="{x:Bind Path=m_userSubmitCollectionViewModel.SubmitCollectionCanLoadMore,Mode=OneWay}"
+                                    LoadMoreBottomOffset="0"
+                                    LoadMoreCommand="{x:Bind Path=m_userSubmitCollectionViewModel.LoadMoreSubmitCollectionCommand}"
+                                    ItemsSource="{x:Bind Path=m_userSubmitCollectionViewModel.SubmitCollectionItems,Mode=OneWay}"
+                                    ItemClick="SubmitCollection_ItemClick"
+                                    OneRowModeEnabled="False">      
+                                    <toolkit:AdaptiveGridView.ItemContainerStyle>
+                                        <Style TargetType="GridViewItem">
+                                            <Setter Property="Margin" Value="4"></Setter>
+                                        </Style>
+                                    </toolkit:AdaptiveGridView.ItemContainerStyle>
+                                    <toolkit:AdaptiveGridView.ItemTemplate>
+                                        <DataTemplate x:DataType="user:SubmitCollectionItemModel">
+                                            <Grid Background="#00FFFFFF">
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="180"/>
+                                                    <ColumnDefinition />
+                                                </Grid.ColumnDefinitions>
+                                                <Border Grid.Column="0" CornerRadius="{StaticResource ImageCornerRadius}">
+                                                    <Grid>
+                                                        <toolkit:ImageEx IsCacheEnabled="True" PlaceholderSource="/Assets/Thumbnails/Placeholde.png" Stretch="UniformToFill" Source="{x:Bind Path=Cover,Converter={StaticResource imageConvert},ConverterParameter='360w_200h_1c'}"></toolkit:ImageEx>
+                                                        <Border CornerRadius="4" VerticalAlignment="Bottom" HorizontalAlignment="Right" Margin="4" Padding="4 2" Background="#99000000">
+                                                            <TextBlock Foreground="White" FontSize="12">
+                                                                <Run>🎞️</Run>
+                                                                <Run Text="{x:Bind Count}"></Run>
+                                                            </TextBlock>
+                                                        </Border>
+                                                    </Grid>
+                                                </Border>
+                                                <!--<StackPanel Grid.Column="1" Margin="4 0 0 0" VerticalAlignment="Stretch" >
+                                                    <TextBlock MaxLines="2" TextWrapping="Wrap" TextTrimming="CharacterEllipsis" Text="{x:Bind Title}"></TextBlock>
+
+                                                    <TextBlock VerticalAlignment="Bottom" Foreground="Gray" Margin="0 4 0 0">最后更新: <Run Text="{x:Bind Path=LatestUpdateTime,Converter={StaticResource time},ConverterParameter='ts'}"/></TextBlock>
+                                                </StackPanel>-->
+                                                <Grid Grid.Column="1">
+                                                    <Grid.RowDefinitions>
+                                                        <RowDefinition Height="Auto"/>
+                                                        <RowDefinition Height="*"/>
+                                                        <RowDefinition Height="Auto"/>
+                                                    </Grid.RowDefinitions>
+                                                    <StackPanel Grid.Row="0" Margin="8 0 0 0" VerticalAlignment="Top">
+                                                        <TextBlock MaxLines="2" Margin="0 0 0 0" TextTrimming="CharacterEllipsis" Text="{x:Bind Title}" TextWrapping="Wrap"></TextBlock>
+                                                    </StackPanel>
+                                                    <StackPanel Grid.Row="1" Margin="8 0 0 0" VerticalAlignment="Bottom">
+                                                        <TextBlock VerticalAlignment="Bottom" Margin="0 3 0 0" FontSize="13" Foreground="Gray">
+                                                            <!--<Run>类型: </Run>-->
+                                                            <Run  Text="{x:Bind Path=Type}"></Run>
+                                                        </TextBlock>
+                                                    </StackPanel>
+                                                    <StackPanel Grid.Row="2" Margin="8 0 0 0" VerticalAlignment="Bottom">
+                                                        <TextBlock Margin="0 3 0 0" FontSize="14" Foreground="Gray">
+                                                             <Run>最后更新: </Run>
+                                                             <Run Text="{x:Bind Path=LatestUpdateTime,Converter={StaticResource time},ConverterParameter='ts'}"></Run>
+                                                        </TextBlock>
+                                                    </StackPanel>
+                                                </Grid>
+                                            </Grid>
+                                        </DataTemplate>
+                                    </toolkit:AdaptiveGridView.ItemTemplate>
+                                    <toolkit:AdaptiveGridView.Footer>
+                                        <StackPanel>
+                                            <HyperlinkButton  Command="{x:Bind Path=m_userSubmitCollectionViewModel.LoadMoreSubmitCollectionCommand}" Visibility="{x:Bind Path=m_userSubmitCollectionViewModel.SubmitCollectionCanLoadMore,Mode=OneWay}" Foreground="Gray" HorizontalAlignment="Center">
+                                                <TextBlock>加载更多</TextBlock>
+                                            </HyperlinkButton>
+                                            <ProgressRing IsActive="True" HorizontalAlignment="Center" Visibility="{x:Bind Path=m_userSubmitCollectionViewModel.LoadingSubmitCollection,Mode=OneWay}"></ProgressRing>
+                                        </StackPanel>
+                                    </toolkit:AdaptiveGridView.Footer>
+                                </control:MyAdaptiveGridView>
+                                <TextBlock Visibility="{x:Bind Path=m_userSubmitCollectionViewModel.Nothing,Mode=OneWay}" Text="这里什么都没有呢..." Foreground="Gray" VerticalAlignment="Center" HorizontalAlignment="Center"></TextBlock>
+                                <control:RoundButton Command="{x:Bind Path=m_userSubmitCollectionViewModel.RefreshSubmitCollectionCommand}"  VerticalAlignment="Bottom" Padding="12" Margin="12" HorizontalAlignment="Right">
+                                    <SymbolIcon Symbol="Refresh" Foreground="White"></SymbolIcon>
+                                </control:RoundButton>
+                            </Grid>
+
+                        </PivotItem>
                         <PivotItem Margin="0">
                             <PivotItem.Header>
                                 <TextBlock FontSize="15">收藏<Run Foreground="Gray" FontSize="12" Text="{x:Bind Path=userDetailVM.UserInfo.stat.favourite,Mode=OneWay}"/></TextBlock>

--- a/src/BiliLite.UWP/Pages/UserInfoPage.xaml
+++ b/src/BiliLite.UWP/Pages/UserInfoPage.xaml
@@ -430,11 +430,6 @@
                                                         </Border>
                                                     </Grid>
                                                 </Border>
-                                                <!--<StackPanel Grid.Column="1" Margin="4 0 0 0" VerticalAlignment="Stretch" >
-                                                    <TextBlock MaxLines="2" TextWrapping="Wrap" TextTrimming="CharacterEllipsis" Text="{x:Bind Title}"></TextBlock>
-
-                                                    <TextBlock VerticalAlignment="Bottom" Foreground="Gray" Margin="0 4 0 0">最后更新: <Run Text="{x:Bind Path=LatestUpdateTime,Converter={StaticResource time},ConverterParameter='ts'}"/></TextBlock>
-                                                </StackPanel>-->
                                                 <Grid Grid.Column="1">
                                                     <Grid.RowDefinitions>
                                                         <RowDefinition Height="Auto"/>

--- a/src/BiliLite.UWP/Pages/UserInfoPage.xaml.cs
+++ b/src/BiliLite.UWP/Pages/UserInfoPage.xaml.cs
@@ -39,6 +39,7 @@ namespace BiliLite.Pages
         readonly UserDynamicViewModel m_userDynamicViewModel;
         UserDetailVM userDetailVM;
         UserSubmitVideoViewModel m_userSubmitVideoViewModel;
+        UserSubmitCollectionViewModel m_userSubmitCollectionViewModel;
         UserSubmitArticleVM userSubmitArticleVM;
         UserFavlistVM userFavlistVM;
         UserFollowVM fansVM;
@@ -51,6 +52,7 @@ namespace BiliLite.Pages
             Title = "用户中心";
             userDetailVM = new Modules.User.UserDetailVM();
             m_userSubmitVideoViewModel = App.ServiceProvider.GetService<UserSubmitVideoViewModel>();
+            m_userSubmitCollectionViewModel = new UserSubmitCollectionViewModel();
             userSubmitArticleVM = new UserSubmitArticleVM();
             userFavlistVM = new UserFavlistVM();
             m_userDynamicViewModel = new UserDynamicViewModel();
@@ -133,6 +135,7 @@ namespace BiliLite.Pages
                 }
                 userDetailVM.mid = mid;
                 m_userSubmitVideoViewModel.Mid = mid;
+                m_userSubmitCollectionViewModel.Mid = mid;
                 userSubmitArticleVM.mid = mid;
                 userFavlistVM.mid = mid;
                 fansVM.mid = mid;
@@ -293,11 +296,15 @@ namespace BiliLite.Pages
             {
                 await userSubmitArticleVM.GetSubmitArticle();
             }
-            if (pivot.SelectedIndex == 3 && userFavlistVM.Items == null)
+            if (pivot.SelectedIndex == 3 && m_userSubmitCollectionViewModel.SubmitCollectionItems == null)
+            {
+                await m_userSubmitCollectionViewModel.GetSubmitCollection();
+            }
+            if (pivot.SelectedIndex == 4 && userFavlistVM.Items == null)
             {
                 await userFavlistVM.Get();
             }
-            if (pivot.SelectedIndex == 4 && followVM.Items == null)
+            if (pivot.SelectedIndex == 5 && followVM.Items == null)
             {
                 if (isSelf)
                 {
@@ -306,7 +313,7 @@ namespace BiliLite.Pages
 
                 await followVM.Get();
             }
-            if (pivot.SelectedIndex == 5 && fansVM.Items == null)
+            if (pivot.SelectedIndex == 6 && fansVM.Items == null)
             {
                 await fansVM.Get();
             }
@@ -322,6 +329,12 @@ namespace BiliLite.Pages
                 title = data.title,
                 parameters = "https://www.bilibili.com/read/cv" + data.id
             });
+        }
+
+        private async void SubmitCollection_ItemClick(object sender, ItemClickEventArgs e)
+        {
+            var data = e.ClickedItem as SubmitCollectionItemModel;
+            await MessageCenter.HandelUrl(data.Uri);
         }
 
         private void comArticleOrder_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/src/BiliLite.UWP/Pages/UserInfoPage.xaml.cs
+++ b/src/BiliLite.UWP/Pages/UserInfoPage.xaml.cs
@@ -22,9 +22,10 @@ namespace BiliLite.Pages
         SubmitVideo = 0,
         Dynamic = 1,
         Article = 2,
-        Favorite = 3,
-        Attention = 4,
-        Fans = 5,
+        Collection = 3,
+        Favorite = 4,
+        Attention = 5,
+        Fans = 6,
     }
     public class UserInfoParameter
     {
@@ -52,7 +53,7 @@ namespace BiliLite.Pages
             Title = "用户中心";
             userDetailVM = new Modules.User.UserDetailVM();
             m_userSubmitVideoViewModel = App.ServiceProvider.GetService<UserSubmitVideoViewModel>();
-            m_userSubmitCollectionViewModel = new UserSubmitCollectionViewModel();
+            m_userSubmitCollectionViewModel = App.ServiceProvider.GetService<UserSubmitCollectionViewModel>();
             userSubmitArticleVM = new UserSubmitArticleVM();
             userFavlistVM = new UserFavlistVM();
             m_userDynamicViewModel = new UserDynamicViewModel();
@@ -333,7 +334,7 @@ namespace BiliLite.Pages
 
         private async void SubmitCollection_ItemClick(object sender, ItemClickEventArgs e)
         {
-            var data = e.ClickedItem as SubmitCollectionItemModel;
+            if (!(e.ClickedItem is SubmitCollectionItemModel data)) return;
             await MessageCenter.HandelUrl(data.Uri);
         }
 

--- a/src/BiliLite.UWP/Services/MessageCenter.cs
+++ b/src/BiliLite.UWP/Services/MessageCenter.cs
@@ -113,6 +113,7 @@ namespace BiliLite.Services
              * bilibili://?av=4284663
              * https://m.bilibili.com/playlist/pl733016988?avid=68818070
              * bilibili://story/722919541
+             * bilibili://music/playlist/playpage/2484684
              */
 
             var video = "";
@@ -167,6 +168,21 @@ namespace BiliLite.Services
                     page = typeof(VideoDetailPage),
                     title = "视频加载中...",
                     parameters = video,
+                    dontGoTo = dontGoTo,
+                });
+                return true;
+            }
+
+            // 目前无法将此类型播放列表的所有视频正确加载进视频页面
+            video = StringExtensions.RegexMatch(url, @"bilibili://music/playlist/playpage/(\d+)");
+            if (video != "")
+            {
+                NavigateToPage(null, new NavigationInfo()
+                {
+                    icon = Symbol.Play,
+                    page = typeof(WebPage),
+                    title = "视频加载中...",
+                    parameters = $"https://www.bilibili.com/list/1?sid={video}",
                     dontGoTo = dontGoTo,
                 });
                 return true;

--- a/src/BiliLite.UWP/ViewModels/User/UserSubmitCollectionViewModel.cs
+++ b/src/BiliLite.UWP/ViewModels/User/UserSubmitCollectionViewModel.cs
@@ -1,0 +1,174 @@
+﻿using AutoMapper;
+using BiliLite.Extensions;
+using BiliLite.Models.Common.User;
+using BiliLite.Models.Exceptions;
+using BiliLite.Models.Requests.Api.User;
+using BiliLite.Modules;
+using BiliLite.Services;
+using BiliLite.ViewModels.Common;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using System.Windows.Input;
+
+namespace BiliLite.ViewModels.User
+{
+    /// <summary>
+    /// 合集投稿
+    /// </summary>
+    public class UserSubmitCollectionViewModel : BaseViewModel
+    {
+        #region Fields
+
+        private static readonly ILogger _logger = GlobalLogger.FromCurrentType();
+        private readonly UserDetailAPI m_userDetailApi;
+
+        #endregion
+
+        #region Constructors
+
+        public UserSubmitCollectionViewModel()
+        {
+            RefreshSubmitCollectionCommand = new RelayCommand(Refresh);
+            LoadMoreSubmitCollectionCommand = new RelayCommand(LoadMore);
+            m_userDetailApi = new UserDetailAPI();
+        }
+
+        #endregion
+
+        #region Properties
+        public ICommand RefreshSubmitCollectionCommand { get; private set; }
+
+        public ICommand LoadMoreSubmitCollectionCommand { get; private set; }
+
+        public string Mid { get; set; }
+
+        public bool LoadingSubmitCollection { get; set; } = true;
+
+        public bool SubmitCollectionCanLoadMore { get; set; }
+
+        public ObservableCollection<SubmitCollectionItemModel> SubmitCollectionItems { get; set; }
+
+        public bool Nothing { get; set; }
+
+        public int SubmitCollectionPage { get; set; } = 1;
+
+        #endregion
+
+        #region Private Methods
+
+        private void GetSubmitCollectionCore(JObject data)
+        {
+            var items = JsonConvert.DeserializeObject<List<SubmitCollectionItemModel>>(data["data"]["items"].ToString());
+            SubmitCollectionPage = data["data"]["page"]["page_num"].ToInt32();
+            var count = data["data"]["page"]["total"].ToInt32();
+            AttachSubmitCollectionItems(items, count);
+            
+        }
+
+        private void AttachSubmitCollectionItems(List<SubmitCollectionItemModel> submitCollectionItems, int count)
+        {
+            if (SubmitCollectionItems == null)
+            {
+                var observableSubmitCollectionItems = new ObservableCollection<SubmitCollectionItemModel>(submitCollectionItems);
+                SubmitCollectionItems = observableSubmitCollectionItems;
+            }
+            else
+            {
+                foreach (var item in submitCollectionItems)
+                {
+                    SubmitCollectionItems.Add(item);
+                }
+            }
+
+            if (SubmitCollectionPage == 1 && SubmitCollectionItems == null)
+            {
+                Nothing = true;
+            }
+            if (SubmitCollectionItems.Count >= count)
+            {
+                SubmitCollectionCanLoadMore = false;
+            }
+            else
+            {
+                SubmitCollectionCanLoadMore = true;
+                SubmitCollectionPage++;
+            }
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public async Task GetSubmitCollection()
+        {
+            try
+            {
+                Nothing = false;
+                SubmitCollectionCanLoadMore = false;
+                LoadingSubmitCollection = true;
+
+                var api = m_userDetailApi.SubmitCollections(Mid, SubmitCollectionPage);
+                var results = await api.Request();
+                if (!results.status)
+                {
+                    throw new CustomizedErrorException(results.message);
+                }
+                var data = results.GetJObject();
+                if (data["code"].ToInt32() != 0)
+                {
+                    throw new CustomizedErrorException(data["message"].ToString());
+                }
+
+                GetSubmitCollectionCore(data);
+            }
+            catch (Exception ex)
+            {
+                if (ex is CustomizedErrorException)
+                {
+                    Notify.ShowMessageToast(ex.Message);
+                }
+                else
+                {
+                    var handel = HandelError<UserSubmitCollectionViewModel>(ex);
+                    Notify.ShowMessageToast(handel.message);
+                }
+
+                _logger.Error("获取用户合集失败", ex);
+            }
+            finally
+            {
+                LoadingSubmitCollection = false;
+            }
+        }
+
+        public async void Refresh()
+        {
+            if (LoadingSubmitCollection)
+            {
+                return;
+            }
+            SubmitCollectionItems = null;
+            SubmitCollectionPage = 1;
+            await GetSubmitCollection();
+        }
+
+        public async void LoadMore()
+        {
+            if (LoadingSubmitCollection)
+            {
+                return;
+            }
+            if (SubmitCollectionItems == null)
+            {
+                return;
+            }
+            await GetSubmitCollection();
+        }
+
+        #endregion
+    }
+}

--- a/src/BiliLite.UWP/ViewModels/User/UserSubmitCollectionViewModel.cs
+++ b/src/BiliLite.UWP/ViewModels/User/UserSubmitCollectionViewModel.cs
@@ -40,6 +40,7 @@ namespace BiliLite.ViewModels.User
         #endregion
 
         #region Properties
+
         public ICommand RefreshSubmitCollectionCommand { get; private set; }
 
         public ICommand LoadMoreSubmitCollectionCommand { get; private set; }
@@ -66,7 +67,6 @@ namespace BiliLite.ViewModels.User
             SubmitCollectionPage = data["data"]["page"]["page_num"].ToInt32();
             var count = data["data"]["page"]["total"].ToInt32();
             AttachSubmitCollectionItems(items, count);
-            
         }
 
         private void AttachSubmitCollectionItems(List<SubmitCollectionItemModel> submitCollectionItems, int count)
@@ -117,6 +117,7 @@ namespace BiliLite.ViewModels.User
                 {
                     throw new CustomizedErrorException(results.message);
                 }
+
                 var data = results.GetJObject();
                 if (data["code"].ToInt32() != 0)
                 {
@@ -125,18 +126,15 @@ namespace BiliLite.ViewModels.User
 
                 GetSubmitCollectionCore(data);
             }
+            catch (CustomizedErrorException ex)
+            {
+                Notify.ShowMessageToast(ex.Message);
+                _logger.Error("获取用户合集失败", ex);
+            }
             catch (Exception ex)
             {
-                if (ex is CustomizedErrorException)
-                {
-                    Notify.ShowMessageToast(ex.Message);
-                }
-                else
-                {
-                    var handel = HandelError<UserSubmitCollectionViewModel>(ex);
-                    Notify.ShowMessageToast(handel.message);
-                }
-
+                var handel = HandelError<UserSubmitCollectionViewModel>(ex);
+                Notify.ShowMessageToast(handel.message);
                 _logger.Error("获取用户合集失败", ex);
             }
             finally


### PR DESCRIPTION
close #438
为个人主页添加了合集选项，效果如下：
![image](https://github.com/ywmoyue/biliuwp-lite/assets/82302542/24b5d9fb-8b67-4f74-8d27-44ac83e4a541)
另外还调整了一些外观方面的参数

仍有少许问题。 如直播回放，其从api获取的类似于`bilibili://music/playlist/playpage/2484684`, 现在不可被程序正确解析。
因此先调用WebPage作为临时方案。

该格式为一播放列表，在ipad端点击时会将尾部的数字id进行一个额外的api请求：`GET api.bilibili.com/x/v2/medialist/resource/list`并将id传入，返回类似于`翻页式`的这个播放列表的各个视频信息。可能需要重新设计视频界面来适配这一播放列表形式。
![image](https://github.com/ywmoyue/biliuwp-lite/assets/82302542/3b6ecc12-dce7-4e7a-82a5-f5d6cc9eff3b)
