### PR TITLE
修复直播分区相关问题

### DIFF
--- a/src/BiliLite.UWP/Converters/ImageCompressionConvert.cs
+++ b/src/BiliLite.UWP/Converters/ImageCompressionConvert.cs
@@ -21,7 +21,7 @@ namespace BiliLite.Converters
                 return value;
             }
             if (parameter == null) return value;
-            return value.ToString() + "@" + parameter.ToString() + ".jpg";
+            return value.ToString() + "@" + parameter.ToString() + ".png";
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, string language)

--- a/src/BiliLite.UWP/Models/Requests/Api/Home/LiveAPI.cs
+++ b/src/BiliLite.UWP/Models/Requests/Api/Home/LiveAPI.cs
@@ -12,6 +12,7 @@ namespace BiliLite.Models.Requests.Api.Home
                 baseUrl = "https://api.live.bilibili.com/xlive/app-interface/v2/index/getAllList",
                 parameter = ApiHelper.MustParameter(AppKey, true) + "&device=android&rec_page=1&relation_page=1&scale=xxhdpi",
             };
+            api.parameter = api.parameter.Replace("mobi_app=iphone", "mobi_app=android"); //只有mobi_app=android才能拿到area_entrance_v2
             api.parameter += ApiHelper.GetSign(api.parameter, AppKey);
             return api;
         }

--- a/src/BiliLite.UWP/Modules/Home/LiveVM.cs
+++ b/src/BiliLite.UWP/Modules/Home/LiveVM.cs
@@ -230,9 +230,6 @@ namespace BiliLite.Modules
         public string link { get; set; }
     }
 
-
-
-
     public class LivePendentItemModel
     {
         public string bg_pic { get; set; }

--- a/src/BiliLite.UWP/Pages/Home/LivePage.xaml
+++ b/src/BiliLite.UWP/Pages/Home/LivePage.xaml
@@ -39,7 +39,12 @@
                         <GridView.ItemTemplate>
                             <DataTemplate x:DataType="model:LiveHomeAreaModel">
                                 <StackPanel>
-                                    <Image Width="48" Margin="0 8" Height="48" Source="{x:Bind pic}"></Image>
+                                    <toolkit:ImageEx Width="48" Margin="0 4" Height="48"
+                                                     IsCacheEnabled="True" 
+                                                     CornerRadius="{StaticResource ImageCornerRadius}"
+                                                     PlaceholderStretch="UniformToFill" 
+                                                     PlaceholderSource="/assets/Thumbnails/Placeholde1x1.png" 
+                                                     Source="{x:Bind Path=pic,Converter={StaticResource imageConvert},ConverterParameter='96w'}"/>
                                     <TextBlock Margin="0 0 0 8" TextAlignment="Center" Text="{x:Bind title}"></TextBlock>
                                 </StackPanel>
                             </DataTemplate>

--- a/src/BiliLite.UWP/Pages/Live/LiveAreaPage.xaml
+++ b/src/BiliLite.UWP/Pages/Live/LiveAreaPage.xaml
@@ -5,7 +5,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:BiliLite.Pages.Live"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:modules="using:BiliLite.Modules.Live"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:modules="using:BiliLite.Modules.Live" xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls"
     mc:Ignorable="d"
     Background="Transparent">
     <Page.Resources>
@@ -36,9 +36,14 @@
                         </Style>
                     </GridView.ItemContainerStyle>
                     <GridView.ItemTemplate>
-                            <DataTemplate x:DataType="modules:LiveAreaItemModel">
+                        <DataTemplate x:DataType="modules:LiveAreaItemModel">
                             <StackPanel>
-                                <Image Width="48" Margin="0 8" Height="48" Source="{x:Bind Path=pic}"></Image>
+                                <controls:ImageEx Width="60" Margin="0 4" Height="60" 
+                                    IsCacheEnabled="True" 
+                                    CornerRadius="{StaticResource ImageCornerRadius}" 
+                                    PlaceholderStretch="UniformToFill" 
+                                    PlaceholderSource="/assets/Thumbnails/Placeholde1x1.png" 
+                                    Source="{x:Bind Path=pic,Converter={StaticResource imageConvert},ConverterParameter='120w'}"/>
                                 <TextBlock Margin="0 0 0 8" TextAlignment="Center" Text="{x:Bind name}"></TextBlock>
                             </StackPanel>
                         </DataTemplate>


### PR DESCRIPTION
使用`mobi_app=android`替换掉iphone后可以正常获取直播分区选项。

同时, fix #446 , 问题原因是`娱乐 - 全部娱乐`的`pic`为空导致的。
使用`imageConvert`的功能修复。同时使其更改为请求`.png`
为了使加载的图片被本地缩放导致难看的颗粒感出现加上了两倍于图片宽的请求参数，这样就不糊也不颗粒了。 

更改了直播二级分区的图片大小。现在图片差不多和四个字一样宽了。
![image](https://github.com/ywmoyue/biliuwp-lite/assets/82302542/a0a93d4c-5a38-4bd3-a9b4-d67dc67ac1ed)
