### PR TITLE
修复直播间的一个线路选择问题

### DIFF
--- a/src/BiliLite.UWP/Pages/LiveDetailPage.xaml.cs
+++ b/src/BiliLite.UWP/Pages/LiveDetailPage.xaml.cs
@@ -682,6 +682,7 @@ namespace BiliLite.Pages
             }
             catch (Exception ex)
             {
+                logger.Log("播放失败", LogType.Error, ex);
                 Notify.ShowMessageToast("播放失败" + ex.Message);
             }
         }

--- a/src/BiliLite.UWP/Player/SubPlayers/LiveHlsPlayer.cs
+++ b/src/BiliLite.UWP/Player/SubPlayers/LiveHlsPlayer.cs
@@ -151,11 +151,11 @@ namespace BiliLite.Player
 
             if (defaultPlayerMode == LivePlayerMode.Hls)
             {
-                url = urls.HlsUrls != null ? urls.HlsUrls[selectRouteLine].Url : urls.FlvUrls[selectRouteLine].Url;
+                url = (urls.HlsUrls != null && selectRouteLine < urls.HlsUrls.Count) ? urls.HlsUrls[selectRouteLine].Url : urls.FlvUrls[selectRouteLine].Url;
             }
             else
             {
-                url = urls.FlvUrls != null ? urls.FlvUrls[selectRouteLine].Url : urls.HlsUrls[selectRouteLine].Url;
+                url = (urls.FlvUrls != null && selectRouteLine < urls.FlvUrls.Count) ? urls.FlvUrls[selectRouteLine].Url : urls.HlsUrls[selectRouteLine].Url;
             }
 
             m_url = url;


### PR DESCRIPTION
有时flv的路线选项和hls的不一样多。这样会导致例如`Flv 线路三`无法播放，因为根本没有这个源。
调整了路线选择时的检测，在发现这个路线没有这个源时会调用对方的源播放。