### PR TITLE
画面尺寸添加兼容模式，修复部分设备缩放画面黑屏的问题

### DIFF
--- a/src/BiliLite.UWP/Controls/Player.xaml.cs
+++ b/src/BiliLite.UWP/Controls/Player.xaml.cs
@@ -1086,6 +1086,30 @@ namespace BiliLite.Controls
                     mediaPlayerVideo.Height = this.ActualHeight;
                     mediaPlayerVideo.Width = this.ActualHeight * 4 / 3;
                     break;
+                case 4:
+                    if (m_dashInfo != null)
+                    {
+                        if (((double)this.ActualWidth / (double)this.ActualHeight) <= ((double)m_dashInfo.Video.Width / (double)m_dashInfo.Video.Height))
+                        {
+                            /// 原视频长宽比大于等于窗口长宽比
+                            mediaPlayerVideo.Stretch = Stretch.Fill;
+                            mediaPlayerVideo.Width = this.ActualWidth;
+                            mediaPlayerVideo.Height = this.ActualWidth * (double)m_dashInfo.Video.Height / (double)m_dashInfo.Video.Width;
+                        }
+                        else {
+                            /// 原视频长宽比小于窗口长宽比
+                            mediaPlayerVideo.Stretch = Stretch.Fill;
+                            mediaPlayerVideo.Width = this.ActualHeight * (double)m_dashInfo.Video.Width / (double)m_dashInfo.Video.Height;
+                            mediaPlayerVideo.Height = this.ActualHeight;
+                        }
+                    }
+                    else {
+                        /// 未获取到DASH视频信息则不缩放
+                        mediaPlayerVideo.Stretch = Stretch.None;
+                        mediaPlayerVideo.Width = double.NaN;
+                        mediaPlayerVideo.Height = double.NaN;
+                    }
+                    break;
                 default:
                     break;
             }
@@ -1308,6 +1332,7 @@ namespace BiliLite.Controls
                     if (m_dashInfo != null && m_dashInfo.Audio != null)
                     {
                         info += $"Resolution: {m_dashInfo.Video.Width} x {m_dashInfo.Video.Height}\r\n";
+                        info += $"View Resolution: {(int)mediaPlayerVideo.Width} x {(int)mediaPlayerVideo.Height}\r\n";
                         info += $"Video Codec: {m_dashInfo.Video.Codecs}\r\n";
                         info += $"Video DataRate: {(m_dashInfo.Video.BandWidth / 1024).ToString("0.0")}Kbps\r\n";
                         info += $"Average Frame: {m_dashInfo.Video.FrameRate}\r\n";

--- a/src/BiliLite.UWP/Controls/PlayerControl.xaml
+++ b/src/BiliLite.UWP/Controls/PlayerControl.xaml
@@ -494,6 +494,7 @@
                                             <ComboBoxItem>填充</ComboBoxItem>
                                             <ComboBoxItem>16:9</ComboBoxItem>
                                             <ComboBoxItem>4:3</ComboBoxItem>
+                                            <ComboBoxItem>兼容</ComboBoxItem>
                                         </ComboBox.Items>
                                     </ComboBox>
                                     <ToggleSwitch x:Name="PlayerSettingABPlayMode" Margin="0 8"  Foreground="White" >

--- a/src/BiliLite.UWP/Controls/PlayerControl.xaml.cs
+++ b/src/BiliLite.UWP/Controls/PlayerControl.xaml.cs
@@ -2329,6 +2329,8 @@ namespace BiliLite.Controls
                     BottomBtnLoading.Visibility = Visibility.Visible;
                     BottomBtnPlay.Visibility = Visibility.Collapsed;
                     BottomBtnPause.Visibility = Visibility.Collapsed;
+                    // 更新画面比例
+                    Player.SetRatioMode(PlayerSettingRatio.SelectedIndex);
                     break;
                 case PlayState.Playing:
                     KeepScreenOn(true);

--- a/src/BiliLite.UWP/Player/IBiliPlayer.cs
+++ b/src/BiliLite.UWP/Player/IBiliPlayer.cs
@@ -24,6 +24,10 @@ namespace BiliLite.Player
         /// 保持4：3
         /// </summary>
         S4_3,
+        /// <summary>
+        /// 兼容
+        /// </summary>
+        Compatible
     }
     public enum PlayerState
     {


### PR DESCRIPTION
为画面尺寸添加了兼容模式选项，兼容模式下会在使用Stretch.Fill方法的同时通过计算缩放比例实现正常的尺寸显示。经测试可以修复部分设备使用默认模式的Stretch.Uniform方法导致缩放窗口画面黑屏的问题。此外，测试还发现此模式下播放时窗口缩放性能比默认更好