### PR TITLE
修复直播弹幕延迟问题

### DIFF
--- a/src/BiliLite.UWP/Modules/Live/LiveMessage.cs
+++ b/src/BiliLite.UWP/Modules/Live/LiveMessage.cs
@@ -148,10 +148,10 @@ namespace BiliLite.Modules.Live
                 var text = Encoding.UTF8.GetString(body);
 
                 // 记录此包中的普通弹幕信息个数
-                var danmakuNum = Regex.Matches(text, Regex.Escape("DANMU_MSG"), RegexOptions.IgnoreCase).Count;
+                var danmuCount = Regex.Matches(text, Regex.Escape("DANMU_MSG"), RegexOptions.IgnoreCase).Count;
                 // 记录时间戳
                 var timeStampNow = (long)0;
-                if (danmakuNum > 0)
+                if (danmuCount > 0)
                 {
                     timeStampNow = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
                     PreviousDanmuPackageTimeStamp = PreviousDanmuPackageTimeStamp == 0 ? timeStampNow : PreviousDanmuPackageTimeStamp;
@@ -163,7 +163,7 @@ namespace BiliLite.Modules.Live
                 foreach (var item in textLines)
                 {
                     // 使用上波弹幕到这波的间隔确定延迟
-                    var danmuDelay = (timeStampNow - PreviousDanmuPackageTimeStamp) / danmakuNum * 1.3;
+                    var danmuDelay = (timeStampNow - PreviousDanmuPackageTimeStamp) / danmuCount * 1.3;
                     var delay = ParseMessage(item) switch
                     {
                         MessageDelayType.DanmuMessage => danmuDelay <= 30 ? 30 : danmuDelay, // 常规弹幕类型, 加延迟
@@ -182,7 +182,7 @@ namespace BiliLite.Modules.Live
                     }
                 }
 
-                if (danmakuNum > 0)
+                if (danmuCount > 0)
                 {
                     PreviousDanmuPackageTimeStamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
                 }


### PR DESCRIPTION
现在会使用前一波到这一波的延迟与本波弹幕个数综合判断需要的延迟。
在几个大型直播间试了一下，效果良好，没有延迟。
![屏幕截图 2024-05-11 233545](https://github.com/ywmoyue/biliuwp-lite/assets/82302542/7d74eee0-07e7-4e7c-b997-416e0176da4a)
图为配合寒霜弹幕使的效果

fix #613 