### PR TITLE
直播信息流匹配弹幕消息规则更改

### DIFF
--- a/src/BiliLite.UWP/Modules/Live/LiveMessage.cs
+++ b/src/BiliLite.UWP/Modules/Live/LiveMessage.cs
@@ -195,7 +195,7 @@ namespace BiliLite.Modules.Live
             {
                 var obj = JObject.Parse(jsonMessage);
                 var cmd = obj["cmd"].ToString();
-                if (cmd == ("DANMU_MSG"))
+                if (cmd.StartsWith("DANMU_MSG"))
                 {
                     var msg = new DanmuMsgModel();
                     if (obj["info"] != null && obj["info"].ToArray().Length != 0)


### PR DESCRIPTION
之前 https://github.com/ywmoyue/biliuwp-lite/issues/656#issuecomment-2146451281 说过b站会在特殊时期将直播弹幕的cmd后面加一串未知的数值。 
所以现在用StartsWith来匹配应该适应的情况会更多一点。