### PR TITLE
更新sdk19041

### DIFF
--- a/src/BiliLite.UWP/BiliLite.UWP.csproj
+++ b/src/BiliLite.UWP/BiliLite.UWP.csproj
@@ -1683,7 +1683,7 @@
     <Folder Include="Modules\User\SendDynamic\" />
   </ItemGroup>
   <ItemGroup>
-    <SDKReference Include="WindowsDesktop, Version=10.0.18362.0">
+    <SDKReference Include="WindowsDesktop, Version=10.0.19041.0">
       <Name>Windows Desktop Extensions for the UWP</Name>
     </SDKReference>
   </ItemGroup>


### PR DESCRIPTION
每次来回切换分支我都需要配置正确的sdk及证书#924 ，因此为了便于维护，提前将sdk统一为19041
未来将有两个长期性RP保持更新，一个涉及主题颜色，一个涉及圆角化ui