### PR TITLE
圣诞更新（直播间优化）

### DIFF
--- a/src/BiliLite.UWP/BiliLite.UWP.csproj
+++ b/src/BiliLite.UWP/BiliLite.UWP.csproj
@@ -207,6 +207,7 @@
     <Compile Include="Models\Common\Comment\HotReply.cs" />
     <Compile Include="Models\Common\Danmaku\BiliDanmakuItem.cs" />
     <Compile Include="Models\Common\Dynamic\DynamicUgcSeasonCardModel.cs" />
+    <Compile Include="Models\Common\Live\LiveRoomEmoticon.cs" />
     <Compile Include="Models\Common\MarkdownViewerPagerParameter.cs" />
     <Compile Include="Models\Common\Player\RealPlayerType.cs" />
     <Compile Include="Models\Common\Player\PlaySpeedMenu.cs" />

--- a/src/BiliLite.UWP/Extensions/TimeExtensions.cs
+++ b/src/BiliLite.UWP/Extensions/TimeExtensions.cs
@@ -85,10 +85,10 @@ namespace BiliLite.Extensions
         }
 
         /// <summary>
-        /// 生成时间戳/豪秒
+        /// 生成时间戳/毫秒
         /// </summary>
         /// <returns></returns>
-        public static long GetTimestampMS()
+        public static long GetTimestampMs()
         {
             return Convert.ToInt64((DateTime.Now - new DateTime(1970, 1, 1, 8, 0, 0, 0)).TotalMilliseconds);
         }

--- a/src/BiliLite.UWP/Models/Common/Enumerates.cs
+++ b/src/BiliLite.UWP/Models/Common/Enumerates.cs
@@ -424,6 +424,11 @@
         /// 直播间等级禁言
         /// </summary>
         ChatLevelMute,
+
+        /// <summary>
+        /// 直播间观看人数变动
+        /// </summary>
+        OnlineCountChange,
     }
 
     public enum MessageDelayType {

--- a/src/BiliLite.UWP/Models/Common/Live/LiveMessageHandleActionsMap.cs
+++ b/src/BiliLite.UWP/Models/Common/Live/LiveMessageHandleActionsMap.cs
@@ -257,7 +257,7 @@ namespace BiliLite.Models.Common.Live
             if (match.Success) accompanyDays = match.Groups[1].Value.ToInt32();
 
             var text = info.UserName + 
-                       (isNewGuard ? "\n新开通了" : "\n续费了") +
+                       (isNewGuard ? "\n开通了" : "\n续费了") +
                        $"主播的{info.GiftName}" + 
                        (info.Num > 1 ? $"×{info.Num}个{info.Unit}" : "") +
                        "🎉" +

--- a/src/BiliLite.UWP/Models/Common/Live/LiveMessageHandleActionsMap.cs
+++ b/src/BiliLite.UWP/Models/Common/Live/LiveMessageHandleActionsMap.cs
@@ -40,6 +40,7 @@ namespace BiliLite.Models.Common.Live
                     { MessageType.OnlineRankChange, OnlineRankChange },
                     { MessageType.StopLive, StopLive },
                     { MessageType.ChatLevelMute, ChatLevelMute },
+                    { MessageType.OnlineCountChange, OnlineCountChange }
                 };
         }
 
@@ -71,7 +72,12 @@ namespace BiliLite.Models.Common.Live
 
         private void WatchedChange(LiveRoomViewModel viewModel, object message)
         {
-            viewModel.WatchedNum = (string)message;
+            viewModel.ViewerNumCount = (string)message;
+        }
+
+        private void OnlineCountChange(LiveRoomViewModel viewModel, object message)
+        {
+            viewModel.ViewerNumCount = (string)message + "人在看";
         }
 
         private void Danmu(LiveRoomViewModel viewModel, object message)

--- a/src/BiliLite.UWP/Models/Common/Live/LiveMessageHandleActionsMap.cs
+++ b/src/BiliLite.UWP/Models/Common/Live/LiveMessageHandleActionsMap.cs
@@ -274,6 +274,8 @@ namespace BiliLite.Models.Common.Live
             
             viewModel.Messages.Add(msg);
             if (isNewGuard) viewModel.ReloadGuardList().RunWithoutAwait();
+
+            if (info.UserID == SettingService.Account.UserID.ToString()) viewModel.GetEmoticons().RunWithoutAwait(); // 自己开通了舰长, 有些表情即可解锁
         }
 
         private void RoomChange(LiveRoomViewModel viewModel, object message)

--- a/src/BiliLite.UWP/Models/Common/Live/LiveRoomEmoticon.cs
+++ b/src/BiliLite.UWP/Models/Common/Live/LiveRoomEmoticon.cs
@@ -1,0 +1,99 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace BiliLite.Models.Common.Live
+{
+    public class LiveRoomEmoticonPackage
+    {
+        [JsonProperty("pkg_id")]
+        public int Id { get; set; }
+
+        [JsonProperty("pkg_name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// 表情包类型
+        /// 已知：3为黄豆表情包, 2为房间表情包，5为全站表情包
+        /// </summary>
+        [JsonProperty("pkg_type")]
+        public int Type { get; set; }
+
+        /// <summary>
+        /// 表情包封面图
+        /// </summary>
+        [JsonProperty("current_cover")]
+        public string Cover { get; set; }
+
+        [JsonProperty("unlock_identity")]
+        public int UnlockIdentity { get; set; }
+
+        [JsonProperty("unlock_need_gift")]
+        public int UnlockNeedGift { get; set; }
+
+        [JsonProperty("emoticons")]
+        public ObservableCollection<LiveRoomEmoticon> Emoticons { get; set; }
+    }
+
+    public class LiveRoomEmoticon
+    {
+        [JsonProperty("bulge_display")]
+        public int BulgeDisplay { get; set; }
+
+        [JsonProperty("width")]
+        public int Width { get; set; }
+
+        /// <summary>
+        /// 是否为大表情
+        /// </summary>
+        public bool IsBigSticker => Width > 0;
+
+        [JsonProperty("emoticon_id")]
+        public int Id { get; set; }
+
+        /// <summary>
+        /// 表情包ID, 似乎可以唯一标识一个表情
+        /// </summary>
+        [JsonProperty("emoticon_unique")]
+        public string Unique { get; set; }
+
+        [JsonProperty("descript")]
+        public string Descript { get; set; }
+
+        [JsonProperty("url")]
+        public string Url { get; set; }
+
+        /// <summary>
+        /// 表情文本, 用于显示至弹幕
+        /// </summary>
+        [JsonProperty("emoji")]
+        public string Text { get; set; }
+
+        /// <summary>
+        /// 表情文本 + 解锁需要条件(如有)
+        /// </summary>
+        public string ShowText => Text + (UnlockShowText.Length > 0 ? "\n[" + UnlockShowText + "]" : "");
+
+        /// <summary>
+        /// 0: 未解锁, 1: 已解锁
+        /// </summary>
+        [JsonProperty("perm")]
+        public int Perm { get; set; }
+
+        /// <summary>
+        /// 显示的图片透明度, 未解锁为0.5
+        /// </summary>
+        public double Opacity => Perm == 0 ? 0.5 : 1.0;
+
+        /// <summary>
+        /// 是否显示上锁图标
+        /// </summary>
+        public bool LockIconVisibility => Perm == 0;
+
+        /// <summary>
+        /// 解锁需要的条件
+        /// </summary>
+        [JsonProperty("unlock_show_text")]
+        public string UnlockShowText { get; set; }
+    }
+}

--- a/src/BiliLite.UWP/Models/Requests/Api/Live/LiveRoomAPI.cs
+++ b/src/BiliLite.UWP/Models/Requests/Api/Live/LiveRoomAPI.cs
@@ -4,6 +4,8 @@ using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
 using BiliLite.Models.Common;
+using BiliLite.Models.Common.Live;
+using Newtonsoft.Json;
 
 namespace BiliLite.Models.Requests.Api.Live
 {
@@ -156,7 +158,7 @@ namespace BiliLite.Models.Requests.Api.Live
                 body = ApiHelper.MustParameter(AppKey, true) + $"&actionKey=appkey",
                 need_cookie = true,
             };
-            api.body += $"&biz_code=live&biz_id={roomId}&gift_id={giftId}&gift_num={num}&price=0&bag_id={bagId}&rnd={TimeExtensions.GetTimestampMS()}&ruid={ruid}&uid={SettingService.Account.UserID}";
+            api.body += $"&biz_code=live&biz_id={roomId}&gift_id={giftId}&gift_num={num}&price=0&bag_id={bagId}&rnd={TimeExtensions.GetTimestampMs()}&ruid={ruid}&uid={SettingService.Account.UserID}";
             api.body += ApiHelper.GetSign(api.body, AppKey);
             return api;
         }
@@ -174,7 +176,7 @@ namespace BiliLite.Models.Requests.Api.Live
                 body = ApiHelper.MustParameter(AppKey, true) + $"&actionKey=appkey",
                 need_cookie = true,
             };
-            api.body += $"&biz_code=live&biz_id={roomId}&gift_id={giftId}&gift_num={num}&price={price}&rnd={TimeExtensions.GetTimestampMS()}&ruid={ruid}&uid={SettingService.Account.UserID}";
+            api.body += $"&biz_code=live&biz_id={roomId}&gift_id={giftId}&gift_num={num}&price={price}&rnd={TimeExtensions.GetTimestampMs()}&ruid={ruid}&uid={SettingService.Account.UserID}";
             api.body += ApiHelper.GetSign(api.body, AppKey);
 
             return api;
@@ -192,7 +194,35 @@ namespace BiliLite.Models.Requests.Api.Live
                 baseUrl = $"https://api.live.bilibili.com/api/sendmsg",
                 parameter = ApiHelper.MustParameter(AppKey, true) + $"&actionKey=appkey",
             };
-            api.body = $"cid={roomId}&mid={SettingService.Account.UserID}&msg={Uri.EscapeDataString(text)}&rnd={TimeExtensions.GetTimestampMS()}&mode=1&pool=0&type=json&color=16777215&fontsize=25&playTime=0.0";
+            api.body = $"cid={roomId}&mid={SettingService.Account.UserID}&msg={Uri.EscapeDataString(text)}&rnd={TimeExtensions.GetTimestampMs()}&mode=1&pool=0&type=json&color=16777215&fontsize=25&playTime=0.0";
+            api.parameter += ApiHelper.GetSign(api.body, AppKey);
+            return api;
+        }
+
+        /// <summary>
+        /// ios端使用的发送弹幕api
+        /// 更加高级, 可用于发送大表情等
+        /// </summary>
+        /// <param name="roomId">直播间号</param>
+        /// <param name="emoji">表情信息</param>
+        /// <returns></returns>
+        public ApiModel SendDanmu(int roomId, LiveRoomEmoticon emoji)
+        {
+            var jsonObj = new
+            {
+                content = $"{emoji.Text}",
+                emoticon_unique = $"{emoji.Unique}",
+                dm_type = 1,
+            };
+            var extra = JsonConvert.SerializeObject(jsonObj);
+
+            var api = new ApiModel
+            {
+                method = HttpMethods.Post,
+                baseUrl = $"https://api.live.bilibili.com/xlive/app-room/v1/dM/sendmsg",
+                parameter = ApiHelper.MustParameter(AppKey, true) + $"&actionKey=appkey",
+                body = $"msg={emoji.Unique}&dm_type=1&extra={extra}&cid={roomId}&mid={SettingService.Account.UserID}&ts={TimeExtensions.GetTimestampS()}&rnd={TimeExtensions.GetTimestampMs()}&mode=1&pool=0&type=json&color=16777215&fontsize=25"
+            };
             api.parameter += ApiHelper.GetSign(api.body, AppKey);
             return api;
         }
@@ -398,6 +428,23 @@ namespace BiliLite.Models.Requests.Api.Live
                 need_cookie = true,
                 headers = ApiHelper.GetDefaultHeaders()
             };
+            return api;
+        }
+
+        /// <summary>
+        /// 获取直播间表情
+        /// </summary>
+        /// <param name="room_id">房间号</param>
+        /// <returns></returns>
+        public ApiModel GetLiveRoomEmoticon(int room_id)
+        {
+            var api = new ApiModel()
+            {
+                method = HttpMethods.Get,
+                baseUrl = $"https://api.live.bilibili.com/xlive/web-ucenter/v2/emoticon/GetEmoticons",
+                parameter = ApiHelper.MustParameter(AppKey, true) + $"&actionKey=appkey&room_id={room_id}",
+            };
+            api.parameter += ApiHelper.GetSign(api.parameter, AppKey);
             return api;
         }
     }

--- a/src/BiliLite.UWP/Modules/Live/LiveMessage.cs
+++ b/src/BiliLite.UWP/Modules/Live/LiveMessage.cs
@@ -332,7 +332,7 @@ namespace BiliLite.Modules.Live
                         w.UserID = obj["data"]["uid"].ToString();
                         w.MsgType = obj["data"]["msg_type"].ToInt32();
 
-                        if (obj["data"]["fans_medal"]["medal_level"].ToInt32() != 0)
+                        if (obj["data"]["fans_medal"].ToString().Length != 0 && obj["data"]["fans_medal"]["medal_level"].ToInt32() != 0)
                         {
                             w.MedalName = obj["data"]["fans_medal"]["medal_name"].ToString();
                             w.MedalLevel = obj["data"]["fans_medal"]["medal_level"].ToInt32();
@@ -501,6 +501,13 @@ namespace BiliLite.Modules.Live
                         NewMessage?.Invoke(MessageType.WatchedChange, obj["data"]["text_large"].ToString());
                     }
                     return MessageDelayType.SystemMessage;
+                }
+                else if (cmd == "ONLINE_RANK_COUNT") // 在线人数变动, 即网页端的"房间观众()括号中的数字"
+                {
+                    if (obj["data"] != null)
+                    {
+                        NewMessage?.Invoke(MessageType.OnlineCountChange, obj["data"]["online_count_text"].ToString());
+                    }
                 }
                 else if (cmd == "ONLINE_RANK_V2")
                 {

--- a/src/BiliLite.UWP/Pages/LiveDetailPage.xaml
+++ b/src/BiliLite.UWP/Pages/LiveDetailPage.xaml
@@ -1111,7 +1111,7 @@
                     </HyperlinkButton>
                     <StackPanel Grid.Column="1" Margin="8 0" VerticalAlignment="Center">
                         <TextBlock Text="{x:Bind Path=m_liveRoomViewModel.LiveInfo.AnchorInfo.BaseInfo.Uname,Mode=OneWay}"></TextBlock>
-                        <TextBlock Margin="0 4 0 0" Foreground="Gray" FontSize="12"><Run Text="{x:Bind Path=m_liveRoomViewModel.WatchedNum,Mode=OneWay}"/> 粉丝:<Run Text="{x:Bind Path=m_liveRoomViewModel.LiveInfo.AnchorInfo.RelationInfo.Attention,Converter={StaticResource numberToStringConvert},Mode=OneWay}"/></TextBlock>
+                        <TextBlock Margin="0 4 0 0" Foreground="Gray" FontSize="12"><Run Text="{x:Bind Path=m_liveRoomViewModel.ViewerNumCount,Mode=OneWay}"/> 粉丝:<Run Text="{x:Bind Path=m_liveRoomViewModel.LiveInfo.AnchorInfo.RelationInfo.Attention,Converter={StaticResource numberToStringConvert},Mode=OneWay}"/></TextBlock>
                     </StackPanel>
                     <Button x:Name="BtnAttention" Click="BtnAttention_Click" FontSize="12" Visibility="{x:Bind Path=m_liveRoomViewModel.Attention,Mode=OneWay,Converter={StaticResource display}}" Grid.Column="2" Background="{ThemeResource SystemAccentColor}" Foreground="White">关注</Button>
                     <Button x:Name="BtnCacnelAttention" Click="BtnCacnelAttention_Click" FontSize="12" Visibility="{x:Bind Path=m_liveRoomViewModel.Attention,Mode=OneWay}" Grid.Column="2">已关注</Button>

--- a/src/BiliLite.UWP/Pages/LiveDetailPage.xaml
+++ b/src/BiliLite.UWP/Pages/LiveDetailPage.xaml
@@ -302,7 +302,7 @@
                         <HyperlinkButton Grid.Row="0" Click="BtnOpenDanmuSpace_Click" Padding="0" Margin="4 10 4 2">
                             <Ellipse Width="32" Height="32" StrokeThickness="1" Stroke="{ThemeResource TextColor}">
                                 <Ellipse.Fill>
-                                    <ImageBrush Stretch="UniformToFill" ImageSource="{x:Bind Path=Face,Converter={StaticResource imageConvert2},ConverterParameter='64h',Mode=OneWay}"/>
+                                    <ImageBrush Stretch="UniformToFill" ImageSource="{x:Bind Path=Face,Converter={StaticResource imageConvert2},ConverterParameter='128h',Mode=OneWay}"/>
                                 </Ellipse.Fill>
                             </Ellipse>
                         </HyperlinkButton>
@@ -350,7 +350,7 @@
                             <!--舰长图标-->
                             <Image Grid.Column="2" Visibility="{x:Bind ShowCaptain}" Height="24" VerticalAlignment="Center" Margin="4 0 0 0">
                                 <Image.Source>
-                                    <BitmapImage UriSource="{Binding UserCaptainImage}" DecodePixelWidth="24" DecodePixelHeight="24"/>
+                                    <BitmapImage UriSource="{Binding UserCaptainImage}"/>
                                 </Image.Source>
                             </Image>
                         </Grid>
@@ -362,7 +362,7 @@
                                     <ContentControl Content="{Binding Path=RichText,Mode=OneWay}" Visibility="{x:Bind ShowBigSticker, Converter={StaticResource display}}"></ContentControl>
                                     <Image Visibility="{x:Bind ShowBigSticker}" Height="{x:Bind BigSticker.Height}" Width="{x:Bind BigSticker.Width}">
                                         <Image.Source>
-                                            <BitmapImage UriSource="{x:Bind BigSticker.Url}" DecodePixelWidth="{x:Bind BigSticker.Width}" DecodePixelHeight="{x:Bind BigSticker.Height}"/>
+                                            <BitmapImage UriSource="{x:Bind BigSticker.Url}" />
                                         </Image.Source>
                                     </Image>
                                 </StackPanel>
@@ -878,7 +878,7 @@
                                             <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Center">
                                                 <Ellipse Width="36" Height="36">
                                                     <Ellipse.Fill>
-                                                        <ImageBrush ImageSource="{x:Bind Path=m_liveRoomViewModel.LotteryViewModel.RedPocketLotteryInfo.SenderFace,Converter={StaticResource imageConvert2},ConverterParameter='36h',Mode=OneWay}" Stretch="UniformToFill"/>
+                                                        <ImageBrush ImageSource="{x:Bind Path=m_liveRoomViewModel.LotteryViewModel.RedPocketLotteryInfo.SenderFace,Converter={StaticResource imageConvert2},ConverterParameter='128h',Mode=OneWay}" Stretch="UniformToFill"/>
                                                     </Ellipse.Fill>
                                                 </Ellipse>
                                                 <TextBlock Margin="4 0" TextWrapping="Wrap" Text="{x:Bind Path=m_liveRoomViewModel.LotteryViewModel.RedPocketLotteryInfo.SenderName,Mode=OneWay}" VerticalAlignment="Center"></TextBlock>
@@ -1105,7 +1105,7 @@
                     <HyperlinkButton Padding="0" Click="BtnOpenUser_Click">
                         <Ellipse Width="48" Height="48" >
                             <Ellipse.Fill>
-                                <ImageBrush Stretch="UniformToFill" ImageSource="{x:Bind Path=m_liveRoomViewModel.LiveInfo.AnchorInfo.BaseInfo.Face,Converter={StaticResource imageConvert2},ConverterParameter='64h',Mode=OneWay}"/>
+                                <ImageBrush Stretch="UniformToFill" ImageSource="{x:Bind Path=m_liveRoomViewModel.LiveInfo.AnchorInfo.BaseInfo.Face,Converter={StaticResource imageConvert2},ConverterParameter='128h',Mode=OneWay}"/>
                             </Ellipse.Fill>
                         </Ellipse>
                     </HyperlinkButton>
@@ -1145,11 +1145,11 @@
                                                             <ColumnDefinition Width="Auto"/>
                                                             <ColumnDefinition/>
                                                         </Grid.ColumnDefinitions>
-                                                        <muxc:ProgressBar Grid.ColumnSpan="2" Height="48" Foreground="{x:Bind Path=BackgroundBottomColor,Mode=OneWay,Converter={StaticResource colorConvert}}" Background="Transparent" Value="{x:Bind Path=Time,Mode=OneWay}" Maximum="{x:Bind Path=MaxTime,Mode=OneWay}"></muxc:ProgressBar>
+                                                        <muxc:ProgressBar Grid.ColumnSpan="2" Height="48" MinHeight="48" Foreground="{x:Bind Path=BackgroundBottomColor,Mode=OneWay,Converter={StaticResource colorConvert}}" Background="Transparent" Value="{x:Bind Path=Time,Mode=OneWay}" Maximum="{x:Bind Path=MaxTime,Mode=OneWay}"></muxc:ProgressBar>
 
-                                                        <Ellipse Width="32" Height="32" Margin="2 0 0 0">
+                                                        <Ellipse Width="32" Height="32" Margin="2 0 0 0" StrokeThickness="1" Stroke="Gray">
                                                             <Ellipse.Fill>
-                                                                <ImageBrush ImageSource="{x:Bind Path=Face,Converter={StaticResource imageConvert2},ConverterParameter='48w'}"></ImageBrush>
+                                                                <ImageBrush ImageSource="{x:Bind Path=Face,Converter={StaticResource imageConvert2},ConverterParameter='128w'}"></ImageBrush>
                                                             </Ellipse.Fill>
                                                         </Ellipse>
 
@@ -1169,9 +1169,9 @@
                                                                 </Grid.ColumnDefinitions>
                                                                 <Image Grid.ColumnSpan="3" Margin="0 0 -36 0" HorizontalAlignment="Right" Source="{x:Bind Path=BackgroundImage}"></Image>
                                                                 <Grid Margin="12 4">
-                                                                    <Ellipse  Width="36" Height="36">
+                                                                    <Ellipse  Width="36" Height="36" StrokeThickness="1" Stroke="Gray">
                                                                         <Ellipse.Fill>
-                                                                            <ImageBrush ImageSource="{x:Bind Path=Face,Converter={StaticResource imageConvert2},ConverterParameter='48w'}"></ImageBrush>
+                                                                            <ImageBrush ImageSource="{x:Bind Path=Face,Converter={StaticResource imageConvert2},ConverterParameter='128w'}"></ImageBrush>
                                                                         </Ellipse.Fill>
                                                                     </Ellipse>
                                                                     <Image Source="{x:Bind Path=FaceFrame}"></Image>
@@ -1246,7 +1246,7 @@
                                 <Grid HorizontalAlignment="Center">
                                     <Ellipse Width="56" Height="56" >
                                         <Ellipse.Fill>
-                                            <ImageBrush Stretch="UniformToFill" ImageSource="{x:Bind Path=m_liveRoomViewModel.Profile.Face,Mode=OneWay,Converter={StaticResource imageConvert2},ConverterParameter='56h'}"/>
+                                            <ImageBrush Stretch="UniformToFill" ImageSource="{x:Bind Path=m_liveRoomViewModel.Profile.Face,Mode=OneWay,Converter={StaticResource imageConvert2},ConverterParameter='128h'}"/>
                                         </Ellipse.Fill>
                                     </Ellipse>
                                     <Image Width="24" Height="24" HorizontalAlignment="Right" VerticalAlignment="Bottom" Source="{x:Bind Path=m_liveRoomViewModel.Profile.Verify,Mode=OneWay}"></Image>
@@ -1326,7 +1326,7 @@
                                                             </Border>
                                                             <Ellipse  Margin="8 0 0 0" Width="30" Height="30" >
                                                                 <Ellipse.Fill>
-                                                                    <ImageBrush ImageSource="{x:Bind Path=Face,Converter={StaticResource imageConvert2},ConverterParameter='48h'}"/>
+                                                                    <ImageBrush ImageSource="{x:Bind Path=Face,Converter={StaticResource imageConvert2},ConverterParameter='128h'}"/>
                                                                 </Ellipse.Fill>
                                                             </Ellipse>
                                                             <TextBlock Margin="4 0 0 0" Text="{x:Bind Uname}" VerticalAlignment="Center"></TextBlock>
@@ -1374,7 +1374,7 @@
                                                     </Image>
                                                     <Ellipse Width="30" Height="30" Margin="4 0">
                                                         <Ellipse.Fill>
-                                                            <ImageBrush ImageSource="{x:Bind Face,Converter={StaticResource imageConvert2},ConverterParameter='30h',Mode=OneWay}" Stretch="UniformToFill"/>
+                                                            <ImageBrush ImageSource="{x:Bind Face,Converter={StaticResource imageConvert2},ConverterParameter='128h',Mode=OneWay}" Stretch="UniformToFill"/>
                                                         </Ellipse.Fill>
                                                     </Ellipse>
                                                     <TextBlock Margin="4 0" VerticalAlignment="Center" Text="{x:Bind Username}"></TextBlock>

--- a/src/BiliLite.UWP/Pages/LiveDetailPage.xaml
+++ b/src/BiliLite.UWP/Pages/LiveDetailPage.xaml
@@ -372,6 +372,41 @@
                 </Grid>
             </toolkit:WrapPanel>
         </DataTemplate>
+        <Flyout x:Name="EmojiFlyout">
+            <Grid Width="340" Margin="-6 -8">
+                <Pivot ItemsSource="{x:Bind Path=m_liveRoomViewModel.EmoticonsPackages,Mode=OneWay}">
+                    <Pivot.HeaderTemplate>
+                        <DataTemplate x:DataType="live:LiveRoomEmoticonPackage">
+                            <StackPanel Orientation="Horizontal" Height="36" Padding="0 -4">
+                                <Border VerticalAlignment="Center" Padding="0" CornerRadius="{StaticResource ImageCornerRadius}">
+                                    <Image VerticalAlignment="Center" Source="{x:Bind Cover,Mode=OneWay}" Margin="0 4" Height="34"></Image>
+                                </Border>
+                                <TextBlock VerticalAlignment="Center" FontSize="16" Margin="2 0 0 0" Text="{x:Bind Path=Name,Mode=OneWay}"></TextBlock>
+                            </StackPanel>
+                        </DataTemplate>
+                    </Pivot.HeaderTemplate>
+                    <Pivot.ItemTemplate>
+                        <DataTemplate x:DataType="live:LiveRoomEmoticonPackage">
+                            <GridView ItemsSource="{x:Bind Path=Emoticons,Mode=OneWay}" MaxHeight="300" Width="320" SelectionMode="None" IsItemClickEnabled="True" ItemClick="EmojiItem_Click">
+                                <GridView.ItemTemplate>
+                                    <DataTemplate x:DataType="live:LiveRoomEmoticon">
+                                        <StackPanel Width="64" Margin="4 0">
+                                            <Grid MinHeight="56">
+                                                <FontIcon Visibility="{x:Bind LockIconVisibility,Mode=OneWay}" FontFamily="Segoe MDL2 Assets" Glyph="&#xE72E;" FontSize="36" HorizontalAlignment="Stretch"/>
+                                                <Border VerticalAlignment="Center" Padding="0" HorizontalAlignment="Stretch" CornerRadius="{StaticResource ImageCornerRadius}">
+                                                    <Image Source="{x:Bind Url,Mode=OneWay}" Opacity="{x:Bind Opacity,Mode=OneWay}" MinHeight="56"></Image>
+                                                </Border>
+                                            </Grid>
+                                            <TextBlock TextAlignment="Center" FontSize="12" HorizontalAlignment="Center" Text="{x:Bind ShowText,Mode=OneWay}"></TextBlock>
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </GridView.ItemTemplate>
+                            </GridView>
+                        </DataTemplate>
+                    </Pivot.ItemTemplate>
+                </Pivot>
+            </Grid>
+        </Flyout>
     </Page.Resources>
     <Grid PointerEntered="RootGrid_PointerEntered" PointerExited="RootGrid_PointerExited">
         <Button x:Name="BtnFoucs" Width="0" Height="0" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="-8 -8 0 0" Background="Transparent" BorderThickness="0"></Button>
@@ -660,9 +695,28 @@
                                     <fa:FontAwesome Icon="Solid_Comments" FontSize="20"></fa:FontAwesome>
                                 </HyperlinkButton>-->
                                     </StackPanel>
-                                    <Grid  x:Name="BottomBtnSendDanmakuWide" Visibility="Collapsed" Grid.Column="1" Margin="12 0" MaxWidth="400">
-                                        <TextBox x:Name="SendDanmakuTextBox"  Padding="8 8 56 8" BorderThickness="0"  Foreground="White" Background="#66FFFFFF"  VerticalAlignment="Center" PlaceholderText="发个友善的弹幕见证当下"></TextBox>
-                                        <Button x:Name="SendDanmakuButton"  BorderThickness="0"  Background="Gray" VerticalAlignment="Stretch" HorizontalAlignment="Right" Height="35" Width="56" Foreground="White" Opacity="0.8">发送</Button>
+                                    <Grid x:Name="BottomBtnSendDanmakuWide" Visibility="Collapsed" Grid.Column="1" Margin="12 0" MaxWidth="400">
+                                        <AutoSuggestBox x:Name="DanmuTextWide"
+                                            VerticalAlignment="Center" 
+                                            Padding="8 8 56 8" 
+                                            BorderThickness="0" 
+                                            TextChanged="Danmu_TextChanged"
+                                            QuerySubmitted="DanmuText_QuerySubmitted"
+                                            QueryIcon="Send"
+                                            PlaceholderText="说点什么吧~">
+                                        </AutoSuggestBox>
+                                        <Button
+                                                Click="EmojiButton_Click"
+                                                Margin="0 0 36 0"
+                                                Padding="0"
+                                                Width="32"
+                                                Height="28"
+                                                BorderThickness="0"
+                                                Background="Transparent"
+                                                HorizontalAlignment="Right"
+                                                VerticalAlignment="Center">
+                                            <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xED54;" FontSize="14"/>
+                                        </Button>
                                     </Grid>
 
 
@@ -1233,7 +1287,19 @@
 
                             </ListView>
                             <Grid  Grid.Row="3" Background="{ThemeResource NavigationViewTopPaneBackground}" Padding="8">
-                                <AutoSuggestBox x:Name="DanmuText" QuerySubmitted="DanmuText_QuerySubmitted" QueryIcon="Send" PlaceholderText="说点什么吧"></AutoSuggestBox>
+                                <AutoSuggestBox x:Name="DanmuText" QuerySubmitted="DanmuText_QuerySubmitted" TextChanged="Danmu_TextChanged" QueryIcon="Send" PlaceholderText="说点什么吧"></AutoSuggestBox>
+                                <Button
+                                    Click="EmojiButton_Click"
+                                    Margin="0 0 36 0"
+                                    Padding="0"
+                                    Width="32"
+                                    Height="28"
+                                    BorderThickness="0"
+                                    Background="Transparent"
+                                    HorizontalAlignment="Right"
+                                    VerticalAlignment="Center">         
+                                    <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xED54;" FontSize="14"/>
+                                </Button>
                             </Grid>
                         </Grid>
                     </PivotItem>

--- a/src/BiliLite.UWP/Pages/LiveDetailPage.xaml.cs
+++ b/src/BiliLite.UWP/Pages/LiveDetailPage.xaml.cs
@@ -121,6 +121,12 @@ namespace BiliLite.Pages
                 BottomBtnGiftRow.Visibility = Visibility.Collapsed;
                 BottomGiftBar.Visibility = Visibility.Collapsed;
             };
+            m_liveRoomViewModel.RefreshGuardNum += (_, e) =>
+            {
+                var temp = pivot.SelectedIndex;
+                pivot.SelectedIndex = 3;
+                pivot.SelectedIndex = temp;
+            };
             this.Loaded += LiveDetailPage_Loaded;
             this.Unloaded += LiveDetailPage_Unloaded; 
             

--- a/src/BiliLite.UWP/ViewModels/Live/LiveRoomViewModel.cs
+++ b/src/BiliLite.UWP/ViewModels/Live/LiveRoomViewModel.cs
@@ -145,9 +145,9 @@ namespace BiliLite.ViewModels.Live
         public bool ShowGiftMessage { get; set; }
 
         /// <summary>
-        /// 看过的人数(替代人气值)
+        /// 房间在线观众数量与看过的人数(替代人气值)
         /// </summary>
-        public string WatchedNum { get; set; }
+        public string ViewerNumCount { get; set; }
 
         /// <summary>
         /// 舰长数


### PR DESCRIPTION
**🎄圣诞快乐~**

- **加入了当前房间在线人数显示**
  由于b站信息流的特性，现在可以与之前的看过人数轮换显示于粉丝数旁
- **加入全屏/大屏幕模式下的弹幕输入框**
- **支持发送表情，包括可混杂于普通文本中的黄豆表情与单独发送的大表情**
- **直播间加载速度优化，优先加载视频流和弹幕流**
- **解决之前的有新舰长但PivotHeader上的舰长数不更新的问题**
  原因是当没有选择大航海页时, UI选择懒加载导致只有选择到大航海页才会更新
  解决方案就是有新舰长时闪现加载一下大航海页…… 有更好的办法欢迎提出
- **一些其他的外观与Typo优化**

fix #949 
