### PR TITLE
沿用旧方法解析不带#前缀的颜色代码

### DIFF
--- a/src/BiliLite.UWP/Converters/ColorConvert.cs
+++ b/src/BiliLite.UWP/Converters/ColorConvert.cs
@@ -21,19 +21,14 @@ namespace BiliLite.Converters
                 {
                     if (!string1.Contains("#"))
                     {
+                        if (long.TryParse(string1, out var c))
+                        {
+                            string1 = c.ToString("X2");
+                        }
+                        int desiredLength = string1.Length <= 6 ? 6 : 8;
+                        string1 = string1.PadLeft(desiredLength, '0');
+
                         string1 = "#" + string1;
-                    }
-                    switch (string1.Length)
-                    {
-                        case < 7:
-                            string1 = "#00000000";
-                            break;
-                        case 8:
-                            string1 = string1.Remove(string1.Length - 1);
-                            break;
-                        case > 9:
-                            string1 = string1.Substring(0, 9);
-                            break;
                     }
 
                     color = Microsoft.Toolkit.Uwp.Helpers.ColorHelper.ToColor(string1);


### PR DESCRIPTION
需要判断是否会出现带#前缀的非法参数，如#123f567
#1068