### PR TITLE
修复纯文字动态无法显示的问题

### DIFF
--- a/src/BiliLite.UWP/Controls/DataTemplateSelectors/UserDynamicItemV2DataTemplateSelector.cs
+++ b/src/BiliLite.UWP/Controls/DataTemplateSelectors/UserDynamicItemV2DataTemplateSelector.cs
@@ -20,7 +20,7 @@ namespace BiliLite.Controls.DataTemplateSelectors
                     { 
                         Constants.DynamicTypes.DRAW, (selector, model) =>
                         {
-                            if (model.Dynamic == null) return selector.OtherTemplate;
+                            if (model.Dynamic == null) return selector.WordTemplate;
                             if (model.Dynamic.DynDraw.Items.Count == 1)
                             {
                                 return selector.Draw1x1Template;


### PR DESCRIPTION
b站api现在会将纯文字动态的动态类型改为"DRAW"而不是之前的"WORD"。 而：
https://github.com/SocialSisterYi/bilibili-API-collect/blob/master/docs/dynamic/dynamic_enum.md
中说"DRAW"类型应该是带图的文字动态，但这压根没图，只能说是b站抽风了。

fix #1146 