### PR TITLE
初步加入SponsorBlock功能

### DIFF
--- a/src/BiliLite.UWP/BiliLite.UWP.csproj
+++ b/src/BiliLite.UWP/BiliLite.UWP.csproj
@@ -229,6 +229,7 @@
     <Compile Include="Models\Common\Video\QualityDictonary.cs" />
     <Compile Include="Models\Common\WebPageNavigationInfo.cs" />
     <Compile Include="Models\Exceptions\UnLoginException.cs" />
+    <Compile Include="Models\Requests\Api\SponsorBlockApi.cs" />
     <Compile Include="Models\Theme\ColorItemModel.cs" />
     <Compile Include="Models\Common\Anime\ISeasonItem.cs" />
     <Compile Include="Models\Common\Comment\HotReply.cs" />
@@ -716,6 +717,7 @@
     <Compile Include="ViewModels\Season\SeasonDetailViewModel.cs" />
     <Compile Include="ViewModels\User\UserSubmitCollectionViewModel.cs" />
     <Compile Include="ViewModels\Video\DanmakuViewModel.cs" />
+    <Compile Include="ViewModels\Video\SponsorBlockViewModel.cs" />
     <Compile Include="ViewModels\Video\VideoDetailReqUserViewModel.cs" />
     <Compile Include="ViewModels\Video\VideoDetailRelatesViewModel.cs" />
     <Compile Include="ViewModels\Video\VideoDetailStatViewModel.cs" />

--- a/src/BiliLite.UWP/Controls/PlayerControl.xaml
+++ b/src/BiliLite.UWP/Controls/PlayerControl.xaml
@@ -716,7 +716,7 @@
                                                     <TextBlock Grid.Row="3" FontSize="12" HorizontalAlignment="Center" Margin="0 8" Foreground="Gray" TextDecorations="Underline">
                                                         本功能灵感与数据库来自
                                                         <Hyperlink NavigateUri="https://github.com/hanydd/BilibiliSponsorBlock">
-                                                            <Run Text="B站空降助手(浏览器插件)" />
+                                                            <Run Text="B站空降助手" />
                                                         </Hyperlink>
                                                     </TextBlock>
                                                 </Grid>

--- a/src/BiliLite.UWP/Controls/PlayerControl.xaml
+++ b/src/BiliLite.UWP/Controls/PlayerControl.xaml
@@ -673,11 +673,17 @@
 
                                     <Button
                                         x:Name="BtnOpenWebPlayerToolbar"
+                                        Width="48"
+                                        Height="48"
+                                        Padding="0"
+                                        Background="Transparent"
                                         Click="BtnOpenWebPlayerToolbar_OnClick"
-                                        Visibility="{x:Bind Player.ShowShakaPlayer, Mode=OneWay}">
+                                        Visibility="{x:Bind Player.ShowShakaPlayer, Mode=OneWay}"
+                                        ToolTipService.ToolTip="Web播放器工具箱">
                                         <fa:FontAwesome
                                             Width="28"
                                             Height="28"
+                                            Foreground="White"
                                             Icon="Solid_Tools" />
                                     </Button>
 
@@ -688,7 +694,8 @@
                                         Padding="0"
                                         Background="Transparent"
                                         Click="TopBtnViewPoints_OnClick"
-                                        Visibility="{x:Bind m_viewModel.ShowViewPointsBtn, Mode=OneWay}">
+                                        Visibility="{x:Bind m_viewModel.ShowViewPointsBtn, Mode=OneWay}"
+                                        ToolTipService.ToolTip="看点">
                                         <Image
                                             Width="28"
                                             Height="28"
@@ -701,7 +708,8 @@
                                         Height="48"
                                         Padding="0"
                                         Background="Transparent"
-                                        Click="TopBtnSettingDanmaku_Click">
+                                        Click="TopBtnSettingDanmaku_Click"
+                                        ToolTipService.ToolTip="弹幕设置">
                                         <Image
                                             Width="28"
                                             Height="28"
@@ -713,7 +721,8 @@
                                         Height="48"
                                         Padding="0"
                                         Background="Transparent"
-                                        Click="TopBtnScreenshot_Click">
+                                        Click="TopBtnScreenshot_Click"
+                                        ToolTipService.ToolTip="截图">
                                         <Button.KeyboardAccelerators>
                                             <KeyboardAccelerator Key="F10" />
                                         </Button.KeyboardAccelerators>
@@ -728,7 +737,8 @@
                                         Height="48"
                                         Padding="0"
                                         Background="Transparent"
-                                        Click="TopBtnMore_Click">
+                                        Click="TopBtnMore_Click"
+                                        ToolTipService.ToolTip="更多">
                                         <Image
                                             Width="28"
                                             Height="28"

--- a/src/BiliLite.UWP/Controls/PlayerControl.xaml
+++ b/src/BiliLite.UWP/Controls/PlayerControl.xaml
@@ -692,6 +692,7 @@
                                                         <RowDefinition Height="Auto"/>
                                                         <RowDefinition Height="Auto"/>
                                                         <RowDefinition Height="Auto"/>
+                                                        <RowDefinition Height="Auto"/>
                                                     </Grid.RowDefinitions>
                                                     <Grid Grid.Row="0">
                                                         <Grid HorizontalAlignment="Center">
@@ -712,10 +713,17 @@
 
                                                     <StackPanel Grid.Row="2" x:Name="SponsorBlockStackPanel" HorizontalAlignment="Stretch" Margin="0 8" Spacing="8"/>
 
-                                                    <TextBlock Grid.Row="3" FontSize="12" HorizontalAlignment="Center" Margin="0 8" Foreground="Gray" TextDecorations="Underline">
+                                                    <TextBlock Grid.Row="3" FontSize="12" HorizontalAlignment="Center" Margin="0 16 0 4" Foreground="Gray">
                                                         本功能灵感与数据库来自
                                                         <Hyperlink NavigateUri="https://github.com/hanydd/BilibiliSponsorBlock">
                                                             <Run Text="B站空降助手" />
+                                                        </Hyperlink>
+                                                    </TextBlock>
+
+                                                    <TextBlock Grid.Row="4" FontSize="12" HorizontalAlignment="Center" Foreground="Gray">
+                                                        赠人玫瑰，手有余香🌹
+                                                        <Hyperlink NavigateUri="https://bsbsb.top/donate/">
+                                                            <Run Text="支持原作者提供的数据库" />
                                                         </Hyperlink>
                                                     </TextBlock>
                                                 </Grid>

--- a/src/BiliLite.UWP/Controls/PlayerControl.xaml
+++ b/src/BiliLite.UWP/Controls/PlayerControl.xaml
@@ -672,6 +672,59 @@
                                         Foreground="White" />
 
                                     <Button
+                                        x:Name="BtnSponsorBlock"
+                                        Width="48"
+                                        Height="48"
+                                        Padding="0"
+                                        Background="Transparent"
+                                        
+                                        Visibility="{x:Bind m_viewModel.ShowSponsorBlockBtn}"
+                                        ToolTipService.ToolTip="空降助手">
+                                        <fa:FontAwesome
+                                            Width="28"
+                                            Height="28"
+                                            Foreground="White"
+                                            Icon="Solid_ShieldAlt" />
+                                        <Button.Flyout>
+                                            <Flyout x:Name="SponsorBlockFlyout">
+                                                <Grid Width="300">
+                                                    <Grid.RowDefinitions>
+                                                        <RowDefinition Height="Auto"/>
+                                                        <RowDefinition Height="Auto"/>
+                                                        <RowDefinition Height="Auto"/>
+                                                        <RowDefinition Height="Auto"/>
+                                                    </Grid.RowDefinitions>
+                                                    <Grid Grid.Row="0">
+                                                        <Grid HorizontalAlignment="Center">
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition Width="Auto"/>
+                                                                <ColumnDefinition Width="*"/>
+                                                            </Grid.ColumnDefinitions>
+                                                            <Grid Grid.Column="0" Margin="0 0 10 0" >
+                                                                <fa:FontAwesome Grid.Column="0" FontSize="64" Foreground="DeepSkyBlue" Icon="Solid_ShieldVirus"/>
+                                                                <Ellipse Width="48" Height="48" Fill="DeepSkyBlue" />
+                                                                <fa:FontAwesome Grid.Column="0" Margin="6 0 0 8" FontSize="22" Foreground="White" Icon="Solid_Play"/>
+                                                                <!--因源项目为GPLv3而本项目许可证不明, 因此不能直接引用图标, 选择手动绘制-->
+                                                            </Grid>
+                                                            <TextBlock Grid.Column="1" FontSize="24" FontWeight="Bold" HorizontalAlignment="Left" VerticalAlignment="Center">空降助手</TextBlock>
+                                                        </Grid>
+                                                    </Grid>
+                                                    <TextBlock Grid.Row="1" x:Name="SponsorBlockMsg" FontWeight="SemiBold" HorizontalAlignment="Center" Margin="0 16" FontSize="15"/>
+
+                                                    <StackPanel Grid.Row="2" x:Name="SponsorBlockStackPanel" HorizontalAlignment="Stretch" Margin="0 8" Spacing="8"/>
+
+                                                    <TextBlock Grid.Row="3" FontSize="12" HorizontalAlignment="Center" Margin="0 8" Foreground="Gray" TextDecorations="Underline">
+                                                        本功能灵感与数据库来自
+                                                        <Hyperlink NavigateUri="https://github.com/hanydd/BilibiliSponsorBlock">
+                                                            <Run Text="B站空降助手(浏览器插件)" />
+                                                        </Hyperlink>
+                                                    </TextBlock>
+                                                </Grid>
+                                            </Flyout>
+                                        </Button.Flyout>
+                                    </Button>
+
+                                    <Button
                                         x:Name="BtnOpenWebPlayerToolbar"
                                         Width="48"
                                         Height="48"

--- a/src/BiliLite.UWP/Controls/PlayerControl.xaml
+++ b/src/BiliLite.UWP/Controls/PlayerControl.xaml
@@ -677,7 +677,7 @@
                                         Height="48"
                                         Padding="0"
                                         Background="Transparent"
-                                        Visibility="{x:Bind m_viewModel.ShowSponsorBlockBtn}"
+                                        Visibility="{x:Bind m_viewModel.ShowSponsorBlockBtn, Mode=OneWay}"
                                         ToolTipService.ToolTip="空降助手">
                                         <fa:FontAwesome
                                             Width="28"

--- a/src/BiliLite.UWP/Controls/PlayerControl.xaml
+++ b/src/BiliLite.UWP/Controls/PlayerControl.xaml
@@ -677,7 +677,6 @@
                                         Height="48"
                                         Padding="0"
                                         Background="Transparent"
-                                        
                                         Visibility="{x:Bind m_viewModel.ShowSponsorBlockBtn}"
                                         ToolTipService.ToolTip="空降助手">
                                         <fa:FontAwesome

--- a/src/BiliLite.UWP/Controls/PlayerControl.xaml.cs
+++ b/src/BiliLite.UWP/Controls/PlayerControl.xaml.cs
@@ -909,7 +909,7 @@ namespace BiliLite.Controls
             {
                 foreach (var seg in CurrentPlayItem.SegmentSkip)
                 {
-                    SkipSection(seg, "SkipSponsor", $"自动跳过{seg.SectionName}");
+                    SkipSection(seg, "SkipSponsor", "");
                 }
             }
         }
@@ -917,14 +917,21 @@ namespace BiliLite.Controls
         private void SkipSection(PlayerSkipItem section, string toastId, string message)
         {
             if (section == null) return;
-            if (Math.Abs(section.VideoDuration - (CurrentPlayItem.duration / 1000.0)) > 1.0) return; //视频长度不等, 有可能换过源
 
             var gap = Math.Abs(Player.Position - section.Start);
             if (!section.IsSectionValid || gap > 0.5) return; //更大的宽容范围检测
 
             Task.Delay(TimeSpan.FromSeconds(gap));
-            SetPosition(section.End);
-            m_playerToastService.Show(toastId, message);
+            if (section.CategoryEnum == SponsorBlockType.Sponsor)
+            {
+                SetPosition(section.End);
+                m_playerToastService.Show(toastId, $"自动跳过 {section.SectionName}");
+            }
+            else
+            {
+                var showTime = (long)((section.End - section.Start) * 1000);
+                m_playerToastService.Show(toastId, $"跳过 {section.SectionName} ？", showTime > 10000 ? 10000 : showTime - 1500, section.End);
+            }
         }
 
         private async Task SetPlayItem(int index)

--- a/src/BiliLite.UWP/Controls/PlayerControl.xaml.cs
+++ b/src/BiliLite.UWP/Controls/PlayerControl.xaml.cs
@@ -123,6 +123,7 @@ namespace BiliLite.Controls
         }
 
         private readonly bool m_autoSkipOpEdFlag = false;
+        private readonly bool m_sponsorBlockFlag;
         private DispatcherTimer m_autoRefreshTimer;
         private DispatcherTimer m_positionTimer;
         DispatcherTimer danmuTimer;
@@ -178,6 +179,8 @@ namespace BiliLite.Controls
             m_positionTimer.Tick += PositionTimer_Tick;
             m_autoSkipOpEdFlag = SettingService.GetValue(SettingConstants.Player.AUTO_SKIP_OP_ED,
                 SettingConstants.Player.DEFAULT_AUTO_SKIP_OP_ED);
+            m_sponsorBlockFlag = SettingService.GetValue(SettingConstants.Player.SPONSOR_BLOCK,
+                SettingConstants.Player.DEFAULT_SPONSOR_BLOCK);
 
             Loaded += PlayerControl_Loaded;
             Unloaded += PlayerControl_Unloaded;
@@ -703,7 +706,9 @@ namespace BiliLite.Controls
 
         public void LoadSponsorBlock()
         {
-            if(CurrentPlayItem == null) return;
+            if(CurrentPlayItem == null || !m_sponsorBlockFlag) return;
+            m_viewModel.ShowSponsorBlockBtn = true;
+
             m_viewModel.SponsorBlockSegmentList = CurrentPlayItem.SegmentSkip.OrderBy(x => x.Start).ToList();
 
             AddSegmentToStackPanel(m_viewModel.SponsorBlockSegmentList);

--- a/src/BiliLite.UWP/Controls/PlayerControl.xaml.cs
+++ b/src/BiliLite.UWP/Controls/PlayerControl.xaml.cs
@@ -174,7 +174,7 @@ namespace BiliLite.Controls
             danmuTimer.Interval = TimeSpan.FromSeconds(1);
             danmuTimer.Tick += DanmuTimer_Tick;
 
-            m_positionTimer = new DispatcherTimer() { Interval = TimeSpan.FromSeconds(0.02) };
+            m_positionTimer = new DispatcherTimer() { Interval = TimeSpan.FromMilliseconds(100) };
             m_positionTimer.Tick += PositionTimer_Tick;
             m_autoSkipOpEdFlag = SettingService.GetValue(SettingConstants.Player.AUTO_SKIP_OP_ED,
                 SettingConstants.Player.DEFAULT_AUTO_SKIP_OP_ED);
@@ -918,16 +918,15 @@ namespace BiliLite.Controls
         {
             if (section == null) return;
             var gap = Math.Abs(Player.Position - section.Start);
-            if (!IsSectionValid(section) || gap > 0.1) return;
-            m_playerToastService.Show(toastId, message);
-            Pause();
+            if (!IsSectionValid(section) || gap > 0.5) return; //更大的宽容范围检测
+            Task.Delay(TimeSpan.FromSeconds(gap));
             SetPosition(section.End);
-            Player.Play();
+            m_playerToastService.Show(toastId, message);
         }
 
         private bool IsSectionValid(PlayerSkipItem section)
         {
-            return section.Start != 0 && section.End != 0 && section.Start != section.End;
+            return section.Start != 0 && section.End != 0 && section.Start < section.End;
         }
 
         private async Task SetPlayItem(int index)

--- a/src/BiliLite.UWP/Controls/PlayerControl.xaml.cs
+++ b/src/BiliLite.UWP/Controls/PlayerControl.xaml.cs
@@ -711,6 +711,7 @@ namespace BiliLite.Controls
 
             m_viewModel.SponsorBlockSegmentList = CurrentPlayItem.SegmentSkip.OrderBy(x => x.Start).ToList();
 
+            SponsorBlockStackPanel.Children.Clear();
             AddSegmentToStackPanel(m_viewModel.SponsorBlockSegmentList);
 
             SponsorBlockStackPanel.Visibility =

--- a/src/BiliLite.UWP/Controls/PlayerControl.xaml.cs
+++ b/src/BiliLite.UWP/Controls/PlayerControl.xaml.cs
@@ -909,7 +909,7 @@ namespace BiliLite.Controls
             {
                 foreach (var seg in CurrentPlayItem.SegmentSkip)
                 {
-                    SkipSection(seg, "SkipSponsor", "自动跳过恰饭");
+                    SkipSection(seg, "SkipSponsor", $"自动跳过{seg.SectionName}");
                 }
             }
         }
@@ -917,16 +917,14 @@ namespace BiliLite.Controls
         private void SkipSection(PlayerSkipItem section, string toastId, string message)
         {
             if (section == null) return;
+            if (Math.Abs(section.VideoDuration - (CurrentPlayItem.duration / 1000.0)) > 1.0) return; //视频长度不等, 有可能换过源
+
             var gap = Math.Abs(Player.Position - section.Start);
-            if (!IsSectionValid(section) || gap > 0.5) return; //更大的宽容范围检测
+            if (!section.IsSectionValid || gap > 0.5) return; //更大的宽容范围检测
+
             Task.Delay(TimeSpan.FromSeconds(gap));
             SetPosition(section.End);
             m_playerToastService.Show(toastId, message);
-        }
-
-        private bool IsSectionValid(PlayerSkipItem section)
-        {
-            return section.Start != 0 && section.End != 0 && section.Start < section.End;
         }
 
         private async Task SetPlayItem(int index)

--- a/src/BiliLite.UWP/Controls/PlayerControl.xaml.cs
+++ b/src/BiliLite.UWP/Controls/PlayerControl.xaml.cs
@@ -709,7 +709,12 @@ namespace BiliLite.Controls
             if(CurrentPlayItem == null || !m_sponsorBlockFlag) return;
             m_viewModel.ShowSponsorBlockBtn = true;
 
-            m_viewModel.SponsorBlockSegmentList = CurrentPlayItem.SegmentSkip.OrderBy(x => x.Start).ToList();
+            var vaildSeg = CurrentPlayItem.SegmentSkip
+                .Where(x => x.Cid == CurrentPlayItem.cid) // 区分cid用于多P视频
+                .Where(x => Math.Abs(x.VideoDuration - CurrentPlayItem.duration) <= 2.0) // 剔除视频长度不等，可能换源的视频
+                .OrderBy(x => x.Start) // 排个序
+                .ToList();
+            m_viewModel.SponsorBlockSegmentList = vaildSeg;
 
             SponsorBlockStackPanel.Children.Clear();
             AddSegmentToStackPanel(m_viewModel.SponsorBlockSegmentList);

--- a/src/BiliLite.UWP/Controls/PlayerControl.xaml.cs
+++ b/src/BiliLite.UWP/Controls/PlayerControl.xaml.cs
@@ -701,6 +701,103 @@ namespace BiliLite.Controls
             });
         }
 
+        public void LoadSponsorBlock()
+        {
+            if(CurrentPlayItem == null) return;
+            m_viewModel.SponsorBlockSegmentList = CurrentPlayItem.SegmentSkip.OrderBy(x => x.Start).ToList();
+
+            AddSegmentToStackPanel(m_viewModel.SponsorBlockSegmentList);
+
+            SponsorBlockStackPanel.Visibility =
+                SponsorBlockStackPanel.Children.Count > 0 ? Visibility.Visible : Visibility.Collapsed;
+
+            SponsorBlockMsg.Text = m_viewModel.SponsorBlockSegmentList.Count > 0 ? 
+                $"🎉此视频在数据库中有 {m_viewModel.SponsorBlockSegmentList.Count} 个可跳过片段！" :
+                "😢在数据库中未找到此视频的可跳过片段";
+        }
+
+        public void AddSegmentToStackPanel(List<PlayerSkipItem> list)
+        {
+            if (list == null || list.Count == 0) return;
+
+            foreach (var item in list)
+            {
+                // 创建Button
+                var button = new Button
+                {
+                    HorizontalAlignment = HorizontalAlignment.Stretch,
+                    HorizontalContentAlignment = HorizontalAlignment.Stretch,
+                    VerticalContentAlignment = VerticalAlignment.Stretch,
+                    Background = new SolidColorBrush(Colors.Transparent),
+                };
+
+                // 创建Grid作为Button的内容
+                var grid = new Grid
+                {
+                    HorizontalAlignment = HorizontalAlignment.Stretch,
+                    VerticalAlignment = VerticalAlignment.Stretch
+                };
+
+                // 添加列定义
+                grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+                grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+                grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+                grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+                // 创建圆形提示
+                var ellipse = new Ellipse
+                {
+                    Width = 10,
+                    Height = 10,
+                    Fill = item.Brush,
+                    VerticalAlignment = VerticalAlignment.Stretch,
+                    Margin = new Thickness(0, 0, 8, 0)
+                };
+                Grid.SetColumn(ellipse, 0);
+
+                // 创建第一个TextBlock
+                var textBlock1 = new TextBlock
+                {
+                    Padding = new Thickness(0),
+                    FontSize = 14,
+                    VerticalAlignment = VerticalAlignment.Center,
+                    Margin = new Thickness(0, 0, 0, 2),
+                    Text = item.SegmentName
+                };
+                Grid.SetColumn(textBlock1, 1);
+
+                // 创建第二个TextBlock
+                var textBlock2 = new TextBlock
+                {
+                    Padding = new Thickness(0),
+                    FontSize = 14,
+                    VerticalAlignment = VerticalAlignment.Center,
+                    Margin = new Thickness(0, 0, 0, 2),
+                    HorizontalAlignment = HorizontalAlignment.Right,
+                    Text = $"{TimeSpanStrFormatConverter.Convert(item.Start)} ➡️ {TimeSpanStrFormatConverter.Convert(item.End)}"
+                };
+                Grid.SetColumn(textBlock2, 3);
+
+                // 将控件添加到Grid中
+                grid.Children.Add(ellipse);
+                grid.Children.Add(textBlock1);
+                grid.Children.Add(textBlock2);
+
+                // 将Grid设置为Button的内容
+                button.Content = grid;
+
+                // 设置按钮点击事件为跳到片段结尾并关闭Flyout
+                button.Click += (_, _) =>
+                {
+                    SetPosition(item.End);
+                    SponsorBlockFlyout.Hide();
+                };
+
+                // 将Button添加到StackPanel中
+                SponsorBlockStackPanel.Children.Add(button);
+            }
+        }
+
         public void InitializePlayInfo(List<PlayInfo> playInfos, int index)
         {
             //保持屏幕常亮
@@ -925,12 +1022,12 @@ namespace BiliLite.Controls
             if (section.CategoryEnum == SponsorBlockType.Sponsor)
             {
                 SetPosition(section.End);
-                m_playerToastService.Show(toastId, $"自动跳过 {section.SectionName}");
+                m_playerToastService.Show(toastId, $"自动跳过{section.SegmentName}", seg: section);
             }
             else
             {
                 var showTime = (long)((section.End - section.Start) * 1000);
-                m_playerToastService.Show(toastId, $"跳过 {section.SectionName} ？", showTime > 10000 ? 10000 : showTime - 1500, section.End);
+                m_playerToastService.Show(toastId, $"跳过{section.SegmentName}？", showTime > 10000 ? 10000 : showTime - 1500, section);
             }
         }
 
@@ -1038,6 +1135,8 @@ namespace BiliLite.Controls
                 if (Player.ABPlay.PointB != double.MaxValue)
                     PlayerSettingABPlaySetPointB.Content = "B: " + TimeSpan.FromSeconds(Player.ABPlay.PointB).ToString(@"hh\:mm\:ss\.fff");
             }
+
+            LoadSponsorBlock();
         }
 
 

--- a/src/BiliLite.UWP/Controls/PlayerToast.xaml
+++ b/src/BiliLite.UWP/Controls/PlayerToast.xaml
@@ -34,11 +34,23 @@
             <Border.RenderTransform>
                 <CompositeTransform TranslateY="0" />
             </Border.RenderTransform>
-            <TextBlock
-                x:Name="TxtToolTip"
-                FontSize="14"
-                Foreground="Black"
-                Text="{x:Bind m_viewModel.Text, Mode=OneWay}" />
+            <StackPanel Orientation="Horizontal" VerticalAlignment="Stretch">
+                <TextBlock
+                    x:Name="TxtToolTip"
+                    FontSize="14"
+                    Foreground="Black"
+                    VerticalAlignment="Center"
+                    Text="{x:Bind m_viewModel.Text, Mode=OneWay}" />
+                <Button Margin="16 0 0 0" 
+                        VerticalAlignment="Center"
+                        FontSize="14" 
+                        Visibility="{x:Bind m_viewModel.ShowSkipButton}"
+                        Click="SkipButton_OnClick"
+                        Content="跳过"
+                        BorderBrush="Gray"
+                        BorderThickness="1"
+                        Foreground="Black" />
+            </StackPanel>
         </Border>
     </Grid>
 </UserControl>

--- a/src/BiliLite.UWP/Controls/PlayerToast.xaml
+++ b/src/BiliLite.UWP/Controls/PlayerToast.xaml
@@ -5,6 +5,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:BiliLite.Controls"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:fa="using:FontAwesome5"
     d:DesignHeight="300"
     d:DesignWidth="400"
     mc:Ignorable="d">
@@ -35,21 +36,28 @@
                 <CompositeTransform TranslateY="0" />
             </Border.RenderTransform>
             <StackPanel Orientation="Horizontal" VerticalAlignment="Stretch">
+                <fa:FontAwesome Icon="Solid_ShieldAlt" 
+                                FontSize="36" 
+                                Margin="0 2 12 0"
+                                Foreground="{x:Bind IconBrush}"
+                                VerticalAlignment="Center"
+                                Visibility="{x:Bind ShowIcon}"/>
                 <TextBlock
                     x:Name="TxtToolTip"
                     FontSize="14"
                     Foreground="Black"
                     VerticalAlignment="Center"
                     Text="{x:Bind m_viewModel.Text, Mode=OneWay}" />
-                <Button Margin="16 0 0 0" 
+                <Button Margin="6 0 0 0" 
                         VerticalAlignment="Center"
                         FontSize="14" 
-                        Visibility="{x:Bind m_viewModel.ShowSkipButton}"
+                        Visibility="{x:Bind ShowSkipButton}"
                         Click="SkipButton_OnClick"
                         Content="跳过"
-                        BorderBrush="Gray"
+                        BorderBrush="DarkGray"
                         BorderThickness="1"
-                        Foreground="Black" />
+                        Foreground="Black"
+                        Background="Transparent"/>
             </StackPanel>
         </Border>
     </Grid>

--- a/src/BiliLite.UWP/Controls/PlayerToast.xaml.cs
+++ b/src/BiliLite.UWP/Controls/PlayerToast.xaml.cs
@@ -1,8 +1,10 @@
 ﻿using BiliLite.ViewModels;
 using System;
 using System.Threading.Tasks;
+using Windows.UI;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Animation;
 
 //https://go.microsoft.com/fwlink/?LinkId=234236 上介绍了“用户控件”项模板
@@ -26,11 +28,11 @@ namespace BiliLite.Controls
             set => m_viewModel.Text = value;
         }
 
-        public bool ShowSkipButton
-        {
-            get => m_viewModel.ShowSkipButton;
-            set => m_viewModel.ShowSkipButton = value;
-        }
+        public bool ShowSkipButton { get; set; } = false;
+
+        public SolidColorBrush IconBrush { get; set; }
+
+        public bool ShowIcon => IconBrush != null && IconBrush != new SolidColorBrush(Colors.Transparent);
 
         public void Show()
         {

--- a/src/BiliLite.UWP/Controls/PlayerToast.xaml.cs
+++ b/src/BiliLite.UWP/Controls/PlayerToast.xaml.cs
@@ -1,7 +1,9 @@
-﻿using System.Threading.Tasks;
+﻿using BiliLite.ViewModels;
+using System;
+using System.Threading.Tasks;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media.Animation;
-using BiliLite.ViewModels;
 
 //https://go.microsoft.com/fwlink/?LinkId=234236 上介绍了“用户控件”项模板
 
@@ -10,6 +12,8 @@ namespace BiliLite.Controls
     public sealed partial class PlayerToast : UserControl
     {
         private readonly PlayerToastViewModel m_viewModel;
+        public event EventHandler SkipButtonClick;
+        public event EventHandler HideToast;
 
         public PlayerToast(PlayerToastViewModel viewModel)
         {
@@ -20,6 +24,12 @@ namespace BiliLite.Controls
         public string Text
         {
             set => m_viewModel.Text = value;
+        }
+
+        public bool ShowSkipButton
+        {
+            get => m_viewModel.ShowSkipButton;
+            set => m_viewModel.ShowSkipButton = value;
         }
 
         public void Show()
@@ -40,6 +50,12 @@ namespace BiliLite.Controls
             };
             storyboard.Begin();
             await tcs.Task;
+        }
+
+        private async void SkipButton_OnClick(object sender, RoutedEventArgs e)
+        {
+            SkipButtonClick?.Invoke(this, EventArgs.Empty);
+            HideToast?.Invoke(sender, EventArgs.Empty);
         }
     }
 }

--- a/src/BiliLite.UWP/Controls/Settings/PlaySettingsControl.xaml
+++ b/src/BiliLite.UWP/Controls/Settings/PlaySettingsControl.xaml
@@ -155,6 +155,13 @@
                 <FontIcon FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets" Glyph="&#xE811;" />
             </controls:SettingsExpander.HeaderIcon>
             <controls:SettingsExpander.Items>
+                <controls:SettingsCard Description="自动化跳过视频中的不受欢迎片段" Header="空降助手">
+                    <controls:SettingsCard.HeaderIcon>
+                        <font:FontAwesome Icon="Solid_ShieldAlt" />
+                    </controls:SettingsCard.HeaderIcon>
+                    <ToggleSwitch x:Name="swSponsorBlock" />
+                </controls:SettingsCard>
+
                 <controls:SettingsCard Description="播放完成自动切换下一P" Header="连续播放分P视频">
                     <controls:SettingsCard.HeaderIcon>
                         <FontIcon FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets" Glyph="&#xF8AD;" />

--- a/src/BiliLite.UWP/Controls/Settings/PlaySettingsControl.xaml.cs
+++ b/src/BiliLite.UWP/Controls/Settings/PlaySettingsControl.xaml.cs
@@ -107,6 +107,16 @@ namespace BiliLite.Controls.Settings
             //    });
             //});
 
+            //空降助手
+            swSponsorBlock.IsOn = SettingService.GetValue<bool>(SettingConstants.Player.SPONSOR_BLOCK, true);
+            swSponsorBlock.Loaded += (_, _) =>
+            {
+                swSponsorBlock.Toggled += (_, _) =>
+                {
+                    SettingService.SetValue(SettingConstants.Player.SPONSOR_BLOCK, swSponsorBlock.IsOn);
+                };
+            };
+
             //自动播放
             swAutoPlay.IsOn = SettingService.GetValue<bool>(SettingConstants.Player.AUTO_PLAY, false);
             swAutoPlay.Loaded += new RoutedEventHandler((sender, e) =>

--- a/src/BiliLite.UWP/Controls/Settings/PlaySettingsControl.xaml.cs
+++ b/src/BiliLite.UWP/Controls/Settings/PlaySettingsControl.xaml.cs
@@ -108,7 +108,7 @@ namespace BiliLite.Controls.Settings
             //});
 
             //空降助手
-            swSponsorBlock.IsOn = SettingService.GetValue<bool>(SettingConstants.Player.SPONSOR_BLOCK, true);
+            swSponsorBlock.IsOn = SettingService.GetValue<bool>(SettingConstants.Player.SPONSOR_BLOCK, SettingConstants.Player.DEFAULT_SPONSOR_BLOCK);
             swSponsorBlock.Loaded += (_, _) =>
             {
                 swSponsorBlock.Toggled += (_, _) =>

--- a/src/BiliLite.UWP/Converters/TimeSpanStrFormatConverter.cs
+++ b/src/BiliLite.UWP/Converters/TimeSpanStrFormatConverter.cs
@@ -1,9 +1,28 @@
 ﻿using System;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Data;
 
 namespace BiliLite.Converters;
 
-public static class TimeSpanStrFormatConverter
+public class TimeSpanStrFormatConverter: IValueConverter
 {
+    public object Convert(object value, Type targetType, object parameter, string language)
+    {
+        return value switch
+        {
+            string timeSpanStr => Convert(timeSpanStr),
+            TimeSpan timeSpan => Convert(timeSpan),
+            double seconds => Convert(seconds),
+            long milliseconds => Convert(milliseconds),
+            _ => DependencyProperty.UnsetValue
+        };
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language)
+    {
+        throw new NotImplementedException();
+    }
+
     public static string Convert(string timeSpanStr)
     {
         // 解析输入字符串
@@ -45,5 +64,28 @@ public static class TimeSpanStrFormatConverter
         var format = timeSpan.Hours == 0 ? @"mm\:ss" : @"hh\:mm\:ss";
         // 根据指定格式格式化 TimeSpan
         return timeSpan.ToString(format);
+    }
+
+    /// <summary>
+    /// 将秒数转换为字符串格式
+    /// </summary>
+    /// <param name="secondTime">时间(秒)</param>
+    public static string Convert(double secondTime)
+    {
+        // 将 double 秒数转换为 TimeSpan
+        var timeSpan = TimeSpan.FromSeconds(secondTime);
+        // 根据小时是否为0来动态调整格式字符串
+        var format = timeSpan.Hours == 0 ? @"mm\:ss" : @"hh\:mm\:ss";
+        // 根据指定格式格式化 TimeSpan
+        return timeSpan.ToString(format);
+    }
+
+    /// <summary>
+    /// 将毫秒数转换为字符串格式
+    /// </summary>
+    /// <param name="millisecondTime">时间(毫秒)</param>
+    public static string Convert(long millisecondTime)
+    {
+        return Convert(millisecondTime / 1000.0);
     }
 }

--- a/src/BiliLite.UWP/Models/Common/Enumerates.cs
+++ b/src/BiliLite.UWP/Models/Common/Enumerates.cs
@@ -587,4 +587,44 @@
         TitleDesc,
         TitleAsc,
     }
+
+    public enum SponsorBlockType
+    {
+        /// <summary>
+        /// 广告
+        /// </summary>
+        Sponsor,
+        /// <summary>
+        /// 片头
+        /// </summary>
+        Intro,
+        /// <summary>
+        /// 片尾
+        /// </summary>
+        Outro,
+        /// <summary>
+        /// 无偿/自我推广
+        /// </summary>
+        SelfPromo,
+        /// <summary>
+        /// 精彩时刻/重点
+        /// </summary>
+        PoiHighlight,
+        /// <summary>
+        /// 三连/订阅提醒
+        /// </summary>
+        Interaction,
+        /// <summary>
+        /// 回顾/概要
+        /// </summary>
+        Preview,
+        /// <summary>
+        /// 非音乐部分（仅用于音乐相关视频）
+        /// </summary>
+        MusicOfftopic,
+        /// <summary>
+        /// 空项目
+        /// </summary>
+        None,
+    }
 }

--- a/src/BiliLite.UWP/Models/Common/Player/PlayerSkipItem.cs
+++ b/src/BiliLite.UWP/Models/Common/Player/PlayerSkipItem.cs
@@ -1,9 +1,47 @@
 ﻿namespace BiliLite.Models.Common.Player
 {
+    /// <summary>
+    /// 跳过片段项，包含起止时间、类型、视频时长等信息。
+    /// </summary>
     public class PlayerSkipItem
     {
+        /// <summary>
+        /// 片段起始时间（秒）。
+        /// </summary>
         public double Start { get; set; }
 
+        /// <summary>
+        /// 片段结束时间（秒）。
+        /// </summary>
         public double End { get; set; }
+
+        /// <summary>
+        /// 片段类型（如 sponsor、intro、outro、selfpromo）。
+        /// </summary>
+        public string Category { get; set; }
+
+        /// <summary>
+        /// 片段类型对应的名称。
+        /// </summary>
+        public string SectionName => Category switch
+        {
+            "sponsor" => "广告",
+            "intro" => "过场/开场动画",
+            "outro" => "鸣谢/结束画面",
+            "selfpromo" => "无偿/自我推广",
+            "poi_highlight" => "精彩时刻/重点",
+            _ => "",
+        };
+
+        /// <summary>
+        /// 视频总时长（秒）。用于判断视频是否换源。
+        /// </summary>
+        public float VideoDuration { get; set; }
+
+        /// <summary>
+        /// 判断片段区间是否合法。
+        /// <para>前后可相等是因为有"poi_highlight"即"精彩时刻/重点"这种类型.</para>
+        /// </summary>
+        public bool IsSectionValid => End >= Start && (Start != 0 || End != 0);
     }
 }

--- a/src/BiliLite.UWP/Models/Common/Player/PlayerSkipItem.cs
+++ b/src/BiliLite.UWP/Models/Common/Player/PlayerSkipItem.cs
@@ -23,14 +23,30 @@
         /// <summary>
         /// 片段类型对应的名称。
         /// </summary>
-        public string SectionName => Category switch
+        public string SectionName => CategoryEnum switch
         {
-            "sponsor" => "广告",
-            "intro" => "过场/开场动画",
-            "outro" => "鸣谢/结束画面",
-            "selfpromo" => "无偿/自我推广",
-            "poi_highlight" => "精彩时刻/重点",
+            SponsorBlockType.Sponsor => "广告",
+            SponsorBlockType.Intro => "过场/开场动画",
+            SponsorBlockType.Outro => "鸣谢/结束画面",
+            SponsorBlockType.SelfPromo => "无偿/自我推广",
+            SponsorBlockType.PoiHighlight => "精彩时刻/重点",
+            SponsorBlockType.Interaction => "三连/订阅提醒",
+            SponsorBlockType.Preview => "回顾/概要",
+            SponsorBlockType.MusicOfftopic => "非音乐部分",
             _ => "",
+        };
+
+        public SponsorBlockType CategoryEnum => Category switch
+        {
+            "sponsor" => SponsorBlockType.Sponsor,
+            "intro" => SponsorBlockType.Intro,
+            "outro" => SponsorBlockType.Outro,
+            "selfpromo" => SponsorBlockType.SelfPromo,
+            "poi_highlight" => SponsorBlockType.PoiHighlight,
+            "interaction" => SponsorBlockType.Interaction,
+            "preview" => SponsorBlockType.Preview,
+            "music_offtopic" => SponsorBlockType.MusicOfftopic,
+            _ => SponsorBlockType.None,
         };
 
         /// <summary>

--- a/src/BiliLite.UWP/Models/Common/Player/PlayerSkipItem.cs
+++ b/src/BiliLite.UWP/Models/Common/Player/PlayerSkipItem.cs
@@ -82,6 +82,11 @@ namespace BiliLite.Models.Common.Player
         public float VideoDuration { get; set; }
 
         /// <summary>
+        /// cid 用于区分一个视频的多个分P
+        /// </summary>
+        public string Cid { get; set; }
+
+        /// <summary>
         /// 判断片段区间是否合法。
         /// <para>前后可相等是因为有"poi_highlight"即"精彩时刻/重点"这种类型.</para>
         /// </summary>

--- a/src/BiliLite.UWP/Models/Common/Player/PlayerSkipItem.cs
+++ b/src/BiliLite.UWP/Models/Common/Player/PlayerSkipItem.cs
@@ -1,4 +1,7 @@
-﻿namespace BiliLite.Models.Common.Player
+﻿using Windows.UI;
+using Windows.UI.Xaml.Media;
+
+namespace BiliLite.Models.Common.Player
 {
     /// <summary>
     /// 跳过片段项，包含起止时间、类型、视频时长等信息。
@@ -23,9 +26,9 @@
         /// <summary>
         /// 片段类型对应的名称。
         /// </summary>
-        public string SectionName => CategoryEnum switch
+        public string SegmentName => CategoryEnum switch
         {
-            SponsorBlockType.Sponsor => "广告",
+            SponsorBlockType.Sponsor => "赞助广告",
             SponsorBlockType.Intro => "过场/开场动画",
             SponsorBlockType.Outro => "鸣谢/结束画面",
             SponsorBlockType.SelfPromo => "无偿/自我推广",
@@ -36,6 +39,9 @@
             _ => "",
         };
 
+        /// <summary>
+        /// 片段类型对应的枚举类型, 方便进行匹配。
+        /// </summary>
         public SponsorBlockType CategoryEnum => Category switch
         {
             "sponsor" => SponsorBlockType.Sponsor,
@@ -50,6 +56,27 @@
         };
 
         /// <summary>
+        /// 片段类型对应的颜色画刷。
+        /// </summary>
+        public SolidColorBrush Brush => new(Color);
+
+        /// <summary>
+        /// 片段类型对应的颜色。
+        /// </summary>
+        public Color Color => CategoryEnum switch
+        {
+            SponsorBlockType.Sponsor => Colors.Green, // 赞助广告
+            SponsorBlockType.Intro => Colors.Aqua, // 片头
+            SponsorBlockType.Outro => Colors.Blue, // 片尾
+            SponsorBlockType.SelfPromo => Colors.Yellow, // 无偿/自我推广
+            SponsorBlockType.PoiHighlight => Colors.DeepPink, // 精彩时刻/重点
+            SponsorBlockType.Interaction => Colors.DarkViolet, // 三连/订阅提醒
+            SponsorBlockType.Preview => Colors.DodgerBlue, // 回顾/概要
+            SponsorBlockType.MusicOfftopic => Colors.Red, // 非音乐部分
+            _ => Colors.Gray,
+        };
+
+        /// <summary>
         /// 视频总时长（秒）。用于判断视频是否换源。
         /// </summary>
         public float VideoDuration { get; set; }
@@ -59,5 +86,10 @@
         /// <para>前后可相等是因为有"poi_highlight"即"精彩时刻/重点"这种类型.</para>
         /// </summary>
         public bool IsSectionValid => End >= Start && (Start != 0 || End != 0);
+
+        /// <summary>
+        /// 是否需要跳过按钮。
+        /// </summary>
+        public bool NeedSkipButton => (int)CategoryEnum > 0;
     }
 }

--- a/src/BiliLite.UWP/Models/Common/Player/PlayerSkipItem.cs
+++ b/src/BiliLite.UWP/Models/Common/Player/PlayerSkipItem.cs
@@ -2,8 +2,8 @@
 {
     public class PlayerSkipItem
     {
-        public long Start { get; set; }
+        public double Start { get; set; }
 
-        public long End { get; set; }
+        public double End { get; set; }
     }
 }

--- a/src/BiliLite.UWP/Models/Common/SettingConstants.cs
+++ b/src/BiliLite.UWP/Models/Common/SettingConstants.cs
@@ -803,6 +803,12 @@ namespace BiliLite.Models.Common
             public const string HARDWARE_DECODING = "PlayerHardwareDecoding";
 
             /// <summary>
+            /// 空降助手开关 bool
+            /// </summary>
+            [SettingKey(typeof(bool))]
+            public const string SPONSOR_BLOCK = "SponsorBlock";
+
+            /// <summary>
             /// 自动播放 bool
             /// </summary>
             [SettingKey(typeof(bool))]

--- a/src/BiliLite.UWP/Models/Common/SettingConstants.cs
+++ b/src/BiliLite.UWP/Models/Common/SettingConstants.cs
@@ -809,6 +809,12 @@ namespace BiliLite.Models.Common
             public const string SPONSOR_BLOCK = "SponsorBlock";
 
             /// <summary>
+            /// 默认开启空降助手开关 bool
+            /// </summary>
+            [SettingDefaultValue]
+            public const bool DEFAULT_SPONSOR_BLOCK = true;
+
+            /// <summary>
             /// 自动播放 bool
             /// </summary>
             [SettingKey(typeof(bool))]

--- a/src/BiliLite.UWP/Models/Common/Video/PlayInfo.cs
+++ b/src/BiliLite.UWP/Models/Common/Video/PlayInfo.cs
@@ -53,7 +53,7 @@ namespace BiliLite.Models.Common.Video
         /// </summary>
         public int node_id { get; set; } = 0;
         /// <summary>
-        /// 时长（毫秒）
+        /// 时长（秒）
         /// </summary>
         public long duration { get; set; }
         public LocalPlayInfo LocalPlayInfo { get; set; }

--- a/src/BiliLite.UWP/Models/Common/Video/PlayInfo.cs
+++ b/src/BiliLite.UWP/Models/Common/Video/PlayInfo.cs
@@ -1,6 +1,8 @@
 ﻿//https://go.microsoft.com/fwlink/?LinkId=234236 上介绍了“用户控件”项模板
 
+using BiliLite.Models.Common.Player;
 using BiliLite.Models.Common.Season;
+using System.Collections.Generic;
 
 namespace BiliLite.Models.Common.Video
 {
@@ -66,5 +68,7 @@ namespace BiliLite.Models.Common.Video
         public bool ShowTitlePart => TitlePage != null;
 
         public EpisodeSkip EpisodeSkip { get; set; }
+
+        public List<PlayerSkipItem> SegmentSkip { get; set; }
     }
 }

--- a/src/BiliLite.UWP/Models/Requests/Api/SponsorBlockApi.cs
+++ b/src/BiliLite.UWP/Models/Requests/Api/SponsorBlockApi.cs
@@ -1,4 +1,5 @@
 ﻿using BiliLite.Models.Common;
+using BiliLite.Services;
 using BiliLite.ViewModels.Video;
 using Newtonsoft.Json;
 using System;
@@ -13,7 +14,7 @@ namespace BiliLite.Models.Requests.Api
     {
         /// <summary>
         /// 获取视频的SponsorBlock数据。
-        /// <para>使用sha256HashPrefix作为视频的唯一标识符，保证隐私。</para>
+        /// <para>使用sha256HashPrefix作为视频的标识符，保证隐私。</para>
         /// </summary>
         /// <param name="bvid">视频的BVID</param>
         public ApiModel GetSponsorBlock(string bvid)
@@ -29,7 +30,7 @@ namespace BiliLite.Models.Requests.Api
             var api = new ApiModel()
             {
                 method = HttpMethods.Get,
-                baseUrl = $"http://115.190.32.254:8080/api/skipSegments/{sha256HashPrefix}"
+                baseUrl = $"{ApiHelper.SPONSOR_BLOCK_URL}/skipSegments/{sha256HashPrefix}"
             };
             return api;
         }
@@ -48,7 +49,7 @@ namespace BiliLite.Models.Requests.Api
             var api = new ApiModel()
             {
                 method = HttpMethods.Post,
-                baseUrl = "http://115.190.32.254:8080/api/skipSegments",
+                baseUrl = $"{ApiHelper.SPONSOR_BLOCK_URL}/api/skipSegments",
                 body = JsonConvert.SerializeObject(new 
                 {
                     videoID = bvid,

--- a/src/BiliLite.UWP/Models/Requests/Api/SponsorBlockApi.cs
+++ b/src/BiliLite.UWP/Models/Requests/Api/SponsorBlockApi.cs
@@ -1,0 +1,65 @@
+﻿using BiliLite.Models.Common;
+using BiliLite.ViewModels.Video;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text;
+using Windows.ApplicationModel;
+
+namespace BiliLite.Models.Requests.Api
+{
+    public class SponsorBlockApi
+    {
+        /// <summary>
+        /// 获取视频的SponsorBlock数据。
+        /// <para>使用sha256HashPrefix作为视频的唯一标识符，保证隐私。</para>
+        /// </summary>
+        /// <param name="bvid">视频的BVID</param>
+        public ApiModel GetSponsorBlock(string bvid)
+        {
+            // 计算bvid的sha256并取前4位, 与浏览器插件一致
+            string sha256HashPrefix;
+            using (var sha256 = SHA256.Create())
+            {
+                var hash = sha256.ComputeHash(Encoding.UTF8.GetBytes(bvid));
+                sha256HashPrefix = BitConverter.ToString(hash).Replace("-", "").ToLower().Substring(0, 4);
+            }
+
+            var api = new ApiModel()
+            {
+                method = HttpMethods.Get,
+                baseUrl = $"http://115.190.32.254:8080/api/skipSegments/{sha256HashPrefix}"
+            };
+            return api;
+        }
+
+        /// <summary>
+        /// 提交SponsorBlock数据。
+        /// </summary>
+        /// <param name="bvid">视频的BVID</param>
+        /// <param name="cvid">视频的CID</param>
+        /// <param name="userId">用户ID</param>
+        /// <param name="videoDuration">视频时长（秒）</param>
+        /// <param name="segments">需要跳过的片段列表</param>
+        public ApiModel PostSponsorBlock(string bvid, string cvid, string userId,
+                                         float videoDuration, List<SponsorBlockSegment> segments)
+        {
+            var api = new ApiModel()
+            {
+                method = HttpMethods.Post,
+                baseUrl = "http://115.190.32.254:8080/api/skipSegments",
+                body = JsonConvert.SerializeObject(new 
+                {
+                    videoID = bvid,
+                    cid = cvid,
+                    userID = userId,
+                    userAgent = $"BiliUWP-Lite/{Package.Current.Id.Version.Major}.{Package.Current.Id.Version.Minor}.{Package.Current.Id.Version.Build}",
+                    videoDuration = videoDuration,
+                    segments = segments
+                })
+            };
+            return api;
+        }
+    }
+}

--- a/src/BiliLite.UWP/Pages/VideoDetailPage.xaml.cs
+++ b/src/BiliLite.UWP/Pages/VideoDetailPage.xaml.cs
@@ -272,7 +272,8 @@ namespace BiliLite.Pages
                     title = item.Part.StartsWith(titlePage) ? item.Part : titlePage + " " + item.Part,
                     TitlePage = titlePage,
                     TitlePart = item.Part.TrimStart(' '),
-                    area = m_viewModel.VideoInfo.Title.ParseArea(m_viewModel.VideoInfo.Owner.Mid)
+                    area = m_viewModel.VideoInfo.Title.ParseArea(m_viewModel.VideoInfo.Owner.Mid),
+                    SegmentSkip = m_viewModel.SponsorBlockList
                 });
                 i++;
             }

--- a/src/BiliLite.UWP/Services/ApiHelper.cs
+++ b/src/BiliLite.UWP/Services/ApiHelper.cs
@@ -33,6 +33,9 @@ namespace BiliLite.Services
         //漫游默认的服务器
         public const string ROMAING_PROXY_URL = "https://b.chuchai.vip";
 
+        // SponsorBlock API, 由B站空降助手提供
+        public const string SPONSOR_BLOCK_URL = "https://bsbsb.top/api";
+
         // 抓取ipad端appkey
         public static ApiKeyInfo IPadOsKey = new ApiKeyInfo(Constants.IOS_APP_KEY, "c2ed53a74eeefe3cf99fbd01d8c9c375", Constants.IOS_MOBI_APP, Constants.IOS_USER_AGENT);
 

--- a/src/BiliLite.UWP/Services/PlayerToastService.cs
+++ b/src/BiliLite.UWP/Services/PlayerToastService.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using System.Timers;
 using Windows.UI.Core;
 using Windows.UI.Xaml.Controls;
+using BiliLite.Models.Common.Player;
 
 namespace BiliLite.Services
 {
@@ -70,9 +71,9 @@ namespace BiliLite.Services
         /// </summary>
         /// <param name="key">ToastId</param>
         /// <param name="msg">显示信息</param>
-        /// <param name="showTime">显示时间(毫秒)</param>
-        /// <param name="position">跳转位置. 用于SponsorBlock功能，可选</param>
-        public async void Show(string key, string msg, long showTime, double? position = null)
+        /// <param name="showTime">显示时间(毫秒) 默认2000</param>
+        /// <param name="seg">用于SponsorBlock功能，可选</param>
+        public async void Show(string key, string msg, long showTime = 2000, PlayerSkipItem seg = null)
         {
             if (m_showPlayerToasts.TryGetValue(key, out var toast))
             {
@@ -87,11 +88,12 @@ namespace BiliLite.Services
             newToast.Height = 80;
             newToast.Width = 200;
             newToast.Text = msg;
-            if (position != null)
+            if (seg != null)
             {
                 newToast.Width = 300;
-                newToast.ShowSkipButton = true;
-                newToast.SkipButtonClick += (_, _) => m_playerControl.SetPosition(position.Value);
+                if (seg.NeedSkipButton) newToast.ShowSkipButton = true;
+                newToast.IconBrush = seg.Brush;
+                newToast.SkipButtonClick += (_, _) => m_playerControl.SetPosition(seg.End);
             }
 
             Canvas.SetLeft(newToast, 0);
@@ -113,8 +115,6 @@ namespace BiliLite.Services
             m_showPlayerToastTimers.Add(key, newTimer);
             newTimer.Start();
         }
-
-        public void Show(string key, string msg) => Show(key, msg, 2000);
 
         public async Task Hide(string key, PlayerToast toast, Timer timer)
         {

--- a/src/BiliLite.UWP/Styles/Converter.xaml
+++ b/src/BiliLite.UWP/Styles/Converter.xaml
@@ -23,6 +23,7 @@
     <Convert:CountOrTextConvert x:Name="CountOrTextConvert" />
     <Convert:LiveStatusConverter x:Name="LiveStatusConverter" />
     <Convert:RealPlayerTypeDisplayConverter x:Name="RealPlayerTypeDisplayConverter" />
+    <Convert:TimeSpanStrFormatConverter x:Name="TimeSpanStrFormatConverter"/>
 
     <ToolKitConvert:ColorToDisplayNameConverter x:Key="ColorToDisplayNameConverter" />
 </ResourceDictionary>

--- a/src/BiliLite.UWP/ViewModels/PlayControlViewModel.cs
+++ b/src/BiliLite.UWP/ViewModels/PlayControlViewModel.cs
@@ -2,6 +2,7 @@
 using BiliLite.ViewModels.Common;
 using System.Collections.Generic;
 using BiliLite.Models.Common;
+using BiliLite.Models.Common.Player;
 using BiliLite.Services;
 using BiliLite.Modules;
 
@@ -20,6 +21,10 @@ namespace BiliLite.ViewModels
         public bool ShowViewPointsBtn { get; set; }
 
         public bool ShowWebPlayerToolbar { get; set; }
+
+        public bool ShowSponsorBlockBtn { get; set; } = true;
+
+        public List<PlayerSkipItem> SponsorBlockSegmentList { get; set; }
 
         public List<PlayerInfoViewPoint> ViewPoints { get; set; }
 

--- a/src/BiliLite.UWP/ViewModels/PlayControlViewModel.cs
+++ b/src/BiliLite.UWP/ViewModels/PlayControlViewModel.cs
@@ -22,7 +22,7 @@ namespace BiliLite.ViewModels
 
         public bool ShowWebPlayerToolbar { get; set; }
 
-        public bool ShowSponsorBlockBtn { get; set; } = true;
+        public bool ShowSponsorBlockBtn { get; set; } = false;
 
         public List<PlayerSkipItem> SponsorBlockSegmentList { get; set; }
 

--- a/src/BiliLite.UWP/ViewModels/PlayerToastViewModel.cs
+++ b/src/BiliLite.UWP/ViewModels/PlayerToastViewModel.cs
@@ -5,5 +5,7 @@ namespace BiliLite.ViewModels
     public class PlayerToastViewModel : BaseViewModel
     {
         public string Text { get; set; }
+
+        public bool ShowSkipButton { get; set; } = false;
     }
 }

--- a/src/BiliLite.UWP/ViewModels/PlayerToastViewModel.cs
+++ b/src/BiliLite.UWP/ViewModels/PlayerToastViewModel.cs
@@ -5,7 +5,5 @@ namespace BiliLite.ViewModels
     public class PlayerToastViewModel : BaseViewModel
     {
         public string Text { get; set; }
-
-        public bool ShowSkipButton { get; set; } = false;
     }
 }

--- a/src/BiliLite.UWP/ViewModels/Video/SponsorBlockViewModel.cs
+++ b/src/BiliLite.UWP/ViewModels/Video/SponsorBlockViewModel.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BiliLite.ViewModels.Video
+{
+    public class SponsorBlockSegment
+    {
+        public float[] Segment { get; set; }
+        public string Cid { get; set; }
+        public string Uuid { get; set; }
+        public string Category { get; set; }
+        public string ActionType { get; set; }
+        public int Locked { get; set; }
+        public int Votes { get; set; }
+        public float VideoDuration { get; set; }
+    }
+
+    public class SponsorBlockVideo
+    {
+        public string VideoId { get; set; }
+        public List<SponsorBlockSegment> Segments { get; set; }
+    }
+
+    public class SponsorBlockViewModel
+    {
+        public List<SponsorBlockVideo> Videos { get; set; }
+    }
+}

--- a/src/BiliLite.UWP/ViewModels/Video/SponsorBlockViewModel.cs
+++ b/src/BiliLite.UWP/ViewModels/Video/SponsorBlockViewModel.cs
@@ -6,19 +6,50 @@ namespace BiliLite.ViewModels.Video
 {
     public class SponsorBlockSegment
     {
+        /// <summary>
+        /// 片段的起止时间（秒），通常为长度为2的数组，表示开始和结束时间。
+        /// </summary>
         public float[] Segment { get; set; }
+        /// <summary>
+        /// 视频分段的CID（内容ID）。
+        /// </summary>
         public string Cid { get; set; }
+        /// <summary>
+        /// 该分段的唯一标识符（UUID）。
+        /// </summary>
         public string Uuid { get; set; }
+        /// <summary>
+        /// 分段所属的类别（如广告、片头等）。
+        /// </summary>
         public string Category { get; set; }
+        /// <summary>
+        /// 推荐的操作类型（如跳过、静音等）。
+        /// </summary>
         public string ActionType { get; set; }
+        /// <summary>
+        /// 是否被锁定（1为锁定，0为未锁定）。
+        /// </summary>
         public int Locked { get; set; }
+        /// <summary>
+        /// 该分段的投票数。
+        /// </summary>
         public int Votes { get; set; }
+        /// <summary>
+        /// 视频总时长（秒）。
+        /// </summary>
         public float VideoDuration { get; set; }
     }
 
     public class SponsorBlockVideo
     {
+        /// <summary>
+        /// 视频的bv号
+        /// </summary>
         public string VideoId { get; set; }
+
+        /// <summary>
+        /// 片段列表
+        /// </summary>
         public List<SponsorBlockSegment> Segments { get; set; }
     }
 

--- a/src/BiliLite.UWP/ViewModels/Video/VideoDetailPageViewModel.cs
+++ b/src/BiliLite.UWP/ViewModels/Video/VideoDetailPageViewModel.cs
@@ -290,7 +290,9 @@ namespace BiliLite.Modules
                     Category = seg.Category,
                     VideoDuration = seg.VideoDuration,
                 };
-                if(!item.IsSectionValid || item.CategoryEnum == SponsorBlockType.PoiHighlight) continue; //暂不支持精彩时刻
+                if (!item.IsSectionValid || 
+                    item.CategoryEnum == SponsorBlockType.PoiHighlight || 
+                    item.CategoryEnum == SponsorBlockType.None) continue; //暂不支持精彩时刻
                 SponsorBlockList.Add(item);
             }
         }

--- a/src/BiliLite.UWP/ViewModels/Video/VideoDetailPageViewModel.cs
+++ b/src/BiliLite.UWP/ViewModels/Video/VideoDetailPageViewModel.cs
@@ -266,7 +266,7 @@ namespace BiliLite.Modules
             var results = await sponsorBlockAPI.GetSponsorBlock(bvid).Request();
             if (!results.status)
             {
-                if(results.code is 400 or 404) NotificationShowExtensions.ShowMessageToast("SponsorBlock参数错误/片段为空");
+                if(results.code is 400 or 404) NotificationShowExtensions.ShowMessageToast($"视频{bvid} SponsorBlock API请求错误: {results.code}");
                 _logger.Warn(results.message);
                 return;
             }

--- a/src/BiliLite.UWP/ViewModels/Video/VideoDetailPageViewModel.cs
+++ b/src/BiliLite.UWP/ViewModels/Video/VideoDetailPageViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using AutoMapper;
+using Bilibili.Polymer.App.Search.V1;
 using BiliLite.Extensions;
 using BiliLite.Extensions.Notifications;
 using BiliLite.Models;
@@ -280,15 +281,21 @@ namespace BiliLite.Modules
 
             var video = data.FirstOrDefault(video => video.VideoId == bvid);
             if (video is null) return;
-            // 先做出跳过效果
-            // TODO: 其他类型
-            var skipSegment = video.Segments.Where(seg => seg.Category == "sponsor").ToList();
+
+            List<SponsorBlockSegment> skipSegment = [];
+            skipSegment.AddRange(video.Segments.Where(seg => seg.Category == "sponsor"));
+            // TODO: 添加开关
+            if (true) skipSegment.AddRange(video.Segments.Where(seg => seg.Category == "intro"));
+            if (true) skipSegment.AddRange(video.Segments.Where(seg => seg.Category == "outro"));
+            if (true) skipSegment.AddRange(video.Segments.Where(seg => seg.Category == "selfpromp"));
             foreach (var seg in skipSegment)
             {
                 var item = new PlayerSkipItem
                 {
                     Start = seg.Segment[0],
-                    End = seg.Segment[1]
+                    End = seg.Segment[1],
+                    Category = seg.Category,
+                    VideoDuration = seg.VideoDuration,
                 };
                 SponsorBlockList.Add(item);
             }

--- a/src/BiliLite.UWP/ViewModels/Video/VideoDetailPageViewModel.cs
+++ b/src/BiliLite.UWP/ViewModels/Video/VideoDetailPageViewModel.cs
@@ -266,6 +266,8 @@ namespace BiliLite.Modules
 
         public async Task LoadSponsorBlock(string bvid)
         {
+            SponsorBlockList.Clear();
+
             var results = await sponsorBlockAPI.GetSponsorBlock(bvid).Request();
             if (!results.status)
             {

--- a/src/BiliLite.UWP/ViewModels/Video/VideoDetailPageViewModel.cs
+++ b/src/BiliLite.UWP/ViewModels/Video/VideoDetailPageViewModel.cs
@@ -287,13 +287,13 @@ namespace BiliLite.Modules
             if (video is null) return;
             foreach (var seg in video.Segments)
             {
-                if (Math.Abs(VideoInfo.Duration - seg.VideoDuration) > 2.0) continue; //视频长度不等, 有可能换过源
                 var item = new PlayerSkipItem
                 {
                     Start = seg.Segment[0] != 0 ? seg.Segment[0] : seg.Segment[0] + 0.75, //完全贴合视频开头的片段会报错. 加偏移量
                     End = Math.Abs(seg.Segment[1] - seg.VideoDuration) > 0.5 ? seg.Segment[1] : seg.Segment[1] - 1.5, //完全贴合视频结尾的片段会卡死播放器，加偏移量
                     Category = seg.Category,
                     VideoDuration = seg.VideoDuration,
+                    Cid = seg.Cid,
                 };
                 if (!item.IsSectionValid || 
                     item.CategoryEnum == SponsorBlockType.PoiHighlight || 

--- a/src/BiliLite.UWP/ViewModels/Video/VideoDetailPageViewModel.cs
+++ b/src/BiliLite.UWP/ViewModels/Video/VideoDetailPageViewModel.cs
@@ -183,6 +183,9 @@ namespace BiliLite.Modules
 
         public List<PlayerSkipItem> SponsorBlockList { get; set; } = [];
 
+        public bool ShowSponsorBlock => 
+            SettingService.GetValue(SettingConstants.Player.SPONSOR_BLOCK, SettingConstants.Player.DEFAULT_SPONSOR_BLOCK);
+
         #endregion
 
         #region Private Methods
@@ -371,7 +374,7 @@ namespace BiliLite.Modules
 
                 await LoadVideoTags(data.data.Aid);
 
-                await LoadSponsorBlock(data.data.Bvid);
+                if (ShowSponsorBlock) await LoadSponsorBlock(data.data.Bvid);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
完成了Sponsor部分核心功能。

- [x] 自动跳过
- [x] 手动跳过
- [x] 设置项（包含在"自动化"部分中）
- [x] 可视的跳过列表面板
- [x] https://github.com/ywmoyue/biliuwp-lite/pull/1181/commits/53ef9dead53451c5fe8b4d55a3a5d1b602ba176f 多P视频正确跳过 ([测试视频](https://www.bilibili.com/video/BV1eDEazVErL) 请找其他的视频再多加测试!)

未能做到的：
- [ ] 进度条着色
- [ ] 对片段点赞/点踩
- [ ] 向服务器提交片段

以上的未完成功能的开发优先级依次递减。 
尤其是进度条着色，是向服务器提交片段的基础。
@ywmoyue 您有时间的话可以看一下这个功能怎么实现。感谢！

另外，发现如果将片段起点定为0，会引起播放器报错；
片段结尾定为视频终点，会卡死播放器一段时间。
希望可以检查一下这两个问题是什么问题引起的。

close #874 