### PR TITLE
直播间UI元素优化

### DIFF
--- a/src/BiliLite.UWP/Models/Common/Live/LiveRoomEmoticon.cs
+++ b/src/BiliLite.UWP/Models/Common/Live/LiveRoomEmoticon.cs
@@ -44,6 +44,11 @@ namespace BiliLite.Models.Common.Live
         public int Width { get; set; }
 
         /// <summary>
+        /// 展示宽度
+        /// </summary>
+        public int ShowWidth => IsBigSticker ? 64 : 36;
+
+        /// <summary>
         /// 是否为大表情
         /// </summary>
         public bool IsBigSticker => Width > 0;

--- a/src/BiliLite.UWP/Pages/LiveDetailPage.xaml
+++ b/src/BiliLite.UWP/Pages/LiveDetailPage.xaml
@@ -383,6 +383,7 @@
                                         Click="BtnOpenWebPlayerToolbar_OnClick"
                                         Background="Transparent"
                                         Foreground="White"
+                                        Padding="0"
                                         ToolTipService.ToolTip="Web播放器工具栏"
                                         Width="48"
                                         Height="48"
@@ -438,7 +439,7 @@
                                             <KeyboardAccelerator Key="F10" />
                                         </HyperlinkButton.KeyboardAccelerators>
                                         <fa:FontAwesome
-                                            FontSize="20"
+                                            FontSize="22"
                                             Icon="Solid_Camera"
                                         />
                                     </HyperlinkButton>
@@ -454,7 +455,7 @@
                                         ToolTipService.ToolTip="设置"
                                         Click="HyperlinkButtonOpenFlyout_OnClick">
                                         <fa:FontAwesome
-                                            FontSize="20"
+                                            FontSize="22"
                                             Icon="Solid_Cog"
                                         />
                                         <FlyoutBase.AttachedFlyout>

--- a/src/BiliLite.UWP/Pages/LiveDetailPage.xaml
+++ b/src/BiliLite.UWP/Pages/LiveDetailPage.xaml
@@ -185,7 +185,7 @@
             </toolkit:WrapPanel>
         </DataTemplate>
         <Flyout x:Name="EmojiFlyout">
-            <Grid Width="340">
+            <Grid Width="360">
                 <Pivot ItemsSource="{x:Bind Path=m_liveRoomViewModel.EmoticonsPackages, Mode=OneWay}">
                     <Pivot.Resources>
                         <Style TargetType="PivotItem">
@@ -214,16 +214,18 @@
                     <Pivot.ItemTemplate>
                         <DataTemplate x:DataType="live:LiveRoomEmoticonPackage">
                             <GridView
-                                Width="320"
                                 MaxHeight="300"
                                 IsItemClickEnabled="True"
                                 ItemClick="EmojiItem_Click"
+                                ScrollViewer.VerticalScrollBarVisibility="Hidden"
+                                HorizontalAlignment="Stretch"
+                                VerticalAlignment="Stretch"
                                 ItemsSource="{x:Bind Path=Emoticons, Mode=OneWay}"
                                 SelectionMode="None">
                                 <GridView.ItemTemplate>
                                     <DataTemplate x:DataType="live:LiveRoomEmoticon">
-                                        <StackPanel Width="64" Margin="4,0">
-                                            <Grid MinHeight="56">
+                                        <StackPanel MaxWidth="64" Width="{x:Bind ShowWidth, Mode=OneWay}" VerticalAlignment="Center" Margin="2 4">
+                                            <Grid >
                                                 <FontIcon
                                                     HorizontalAlignment="Stretch"
                                                     FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
@@ -231,8 +233,7 @@
                                                     Glyph="&#xE72E;"
                                                     Visibility="{x:Bind LockIconVisibility, Mode=OneWay}" />
                                                 <Image
-                                                    MinHeight="56"
-                                                    HorizontalAlignment="Stretch"
+                                                    Width="{x:Bind ShowWidth, Mode=OneWay}"
                                                     VerticalAlignment="Center"
                                                     Opacity="{x:Bind Opacity, Mode=OneWay}"
                                                     Source="{x:Bind Url, Mode=OneWay}" />
@@ -240,6 +241,7 @@
                                             <TextBlock
                                                 HorizontalAlignment="Center"
                                                 FontSize="12"
+                                                Visibility="{x:Bind IsBigSticker, Mode=OneWay}"
                                                 Text="{x:Bind ShowText, Mode=OneWay}"
                                                 TextAlignment="Center" />
                                         </StackPanel>

--- a/src/BiliLite.UWP/Pages/LiveDetailPage.xaml
+++ b/src/BiliLite.UWP/Pages/LiveDetailPage.xaml
@@ -370,36 +370,44 @@
                                 </Grid.ColumnDefinitions>
                                 <TextBlock
                                     x:Name="TopTitle"
-                                    Margin="12,0"
+                                    Margin="20,0"
                                     VerticalAlignment="Center"
                                     FontSize="18"
+                                    FontWeight="Medium"
                                     Foreground="White"
                                     Text="{x:Bind Path=m_liveRoomViewModel.RoomTitle, Mode=OneWay}"
                                     TextTrimming="CharacterEllipsis" />
-                                <StackPanel Grid.Column="1" Orientation="Horizontal">
-                                    <Button
+                                <StackPanel Grid.Column="1" Orientation="Horizontal" Margin="0 4 0 0">
+                                    <HyperlinkButton
                                         x:Name="BtnOpenWebPlayerToolbar"
                                         Click="BtnOpenWebPlayerToolbar_OnClick"
+                                        Background="Transparent"
+                                        Foreground="White"
+                                        ToolTipService.ToolTip="Web播放器工具栏"
+                                        Width="48"
+                                        Height="48"
                                         Visibility="{x:Bind m_viewModel.ShowWebPlayer, Mode=OneWay}">
                                         <fa:FontAwesome
-                                            Width="28"
-                                            Height="28"
-                                            Icon="Solid_Tools" />
-                                    </Button>
+                                            FontSize="20"
+                                            Icon="Solid_Tools"
+                                            />
+                                    </HyperlinkButton>
 
-                                    <Button
+                                    <HyperlinkButton
                                         x:Name="TopBtnShare"
                                         Width="48"
                                         Height="48"
                                         Padding="0"
                                         Background="Transparent"
+                                        ToolTipService.ToolTip="分享"
                                         BorderThickness="0"
+                                        Click="HyperlinkButtonOpenFlyout_OnClick"
                                         Foreground="White">
-                                        <FontIcon
-                                            FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
-                                            FontSize="28"
-                                            Glyph="&#xE72D;" />
-                                        <Button.Flyout>
+                                        <fa:FontAwesome
+                                            FontSize="20"
+                                            Icon="Solid_ShareSquare"
+                                        />
+                                        <FlyoutBase.AttachedFlyout>
                                             <MenuFlyout>
                                                 <MenuFlyoutItem
                                                     Click="btnShareCopyUrl_Click"
@@ -414,39 +422,42 @@
                                                     Icon="Share"
                                                     Text="分享到..." />
                                             </MenuFlyout>
-                                        </Button.Flyout>
-                                    </Button>
-                                    <Button
+                                        </FlyoutBase.AttachedFlyout>
+                                    </HyperlinkButton>
+                                    <HyperlinkButton
                                         x:Name="TopBtnScreenshot"
                                         Width="48"
                                         Height="48"
-                                        Margin="8,0,0,0"
                                         Padding="0"
                                         Background="Transparent"
+                                        Foreground="White"
                                         BorderThickness="0"
+                                        ToolTipService.ToolTip="截屏"
                                         Click="TopBtnScreenshot_Click">
-                                        <Button.KeyboardAccelerators>
+                                        <HyperlinkButton.KeyboardAccelerators>
                                             <KeyboardAccelerator Key="F10" />
-                                        </Button.KeyboardAccelerators>
-                                        <Image
-                                            Width="28"
-                                            Height="28"
-                                            Source="/Assets/Icon/icon_screenshot.png" />
-                                    </Button>
+                                        </HyperlinkButton.KeyboardAccelerators>
+                                        <fa:FontAwesome
+                                            FontSize="20"
+                                            Icon="Solid_Camera"
+                                        />
+                                    </HyperlinkButton>
 
-                                    <Button
+                                    <HyperlinkButton
                                         x:Name="TopBtnSetting"
                                         Width="48"
                                         Height="48"
-                                        Margin="8,0,0,0"
                                         Padding="0"
                                         Background="Transparent"
-                                        BorderThickness="0">
-                                        <Image
-                                            Width="32"
-                                            Height="32"
-                                            Source="/Assets/Icon/icon_settings.png" />
-                                        <Button.Flyout>
+                                        Foreground="White"
+                                        BorderThickness="0"
+                                        ToolTipService.ToolTip="设置"
+                                        Click="HyperlinkButtonOpenFlyout_OnClick">
+                                        <fa:FontAwesome
+                                            FontSize="20"
+                                            Icon="Solid_Cog"
+                                        />
+                                        <FlyoutBase.AttachedFlyout>
                                             <Flyout>
                                                 <Pivot Width="325">
                                                     <PivotItem>
@@ -663,8 +674,8 @@
                                                     </PivotItem>
                                                 </Pivot>
                                             </Flyout>
-                                        </Button.Flyout>
-                                    </Button>
+                                        </FlyoutBase.AttachedFlyout>
+                                    </HyperlinkButton>
                                 </StackPanel>
                             </Grid>
                             <Grid Grid.Row="2">
@@ -722,7 +733,7 @@
                                             Foreground="White"
                                             Text="{x:Bind Path=m_liveRoomViewModel.LiveTime, Mode=OneWay}" />
 
-                                        <Button
+                                        <HyperlinkButton
                                             x:Name="TopBtnOpenDanmaku"
                                             Width="48"
                                             Height="48"
@@ -735,8 +746,8 @@
                                                 Width="28"
                                                 Height="28"
                                                 Source="/Assets/Icon/icon_danmaku_open.png" />
-                                        </Button>
-                                        <Button
+                                        </HyperlinkButton>
+                                        <HyperlinkButton
                                             x:Name="TopBtnCloseDanmaku"
                                             Width="48"
                                             Height="48"
@@ -749,19 +760,20 @@
                                                 Width="28"
                                                 Height="28"
                                                 Source="/Assets/Icon/icon_danmaku_close.png" />
-                                        </Button>
-                                        <Button
+                                        </HyperlinkButton>
+                                        <HyperlinkButton
                                             x:Name="TopBtnSettingDanmaku"
                                             Width="48"
                                             Height="48"
                                             Padding="0"
                                             Background="Transparent"
-                                            BorderThickness="0">
+                                            BorderThickness="0"
+                                            Click="HyperlinkButtonOpenFlyout_OnClick">
                                             <Image
                                                 Width="28"
                                                 Height="28"
                                                 Source="/Assets/Icon/icon_danmaku_setting.png" />
-                                            <Button.Flyout>
+                                            <FlyoutBase.AttachedFlyout>
                                                 <Flyout>
                                                     <StackPanel>
                                                         <TextBlock Margin="0,4,0,0">
@@ -834,8 +846,8 @@
 
                                                     </StackPanel>
                                                 </Flyout>
-                                            </Button.Flyout>
-                                        </Button>
+                                            </FlyoutBase.AttachedFlyout>
+                                        </HyperlinkButton>
                                         <!--<HyperlinkButton x:Name="BottomBtnSendDanmaku" Foreground="White" Padding="8" Width="48" Height="48">
                                     <fa:FontAwesome Icon="Solid_Comments" FontSize="20"></fa:FontAwesome>
                                 </HyperlinkButton>-->
@@ -866,7 +878,6 @@
                                             Height="32"
                                             Padding="0"
                                             VerticalAlignment="Center"
-                                            Background="Transparent"
                                             BorderThickness="0"
                                             Click="EmojiButton_Click">
                                             <FontIcon
@@ -882,28 +893,28 @@
                                             x:Name="BottomBtnGiftRow"
                                             Width="48"
                                             Height="48"
-                                            Margin="0,0,10,0"
-                                            Padding="8"
+                                            Padding="8 4 8 8"
                                             Click="BottomBtnSwitchGiftBar_Click"
                                             Foreground="White"
                                             ToolTipService.ToolTip="开关礼物栏">
                                             <fa:FontAwesome FontSize="22" Icon="Solid_Gift" />
                                         </HyperlinkButton>
 
-                                        <Button
+                                        <HyperlinkButton
                                             x:Name="BottomBtnVolume"
                                             Width="48"
                                             Height="48"
-                                            Padding="8"
+                                            Padding="8 4 8 8"
                                             Background="Transparent"
-                                            BorderThickness="0"
                                             Foreground="White"
-                                            ToolTipService.ToolTip="音量">
+                                            BorderThickness="0"
+                                            ToolTipService.ToolTip="音量"
+                                            Click="HyperlinkButtonOpenFlyout_OnClick">
                                             <fa:FontAwesome
                                                 x:Name="BottomBtnVolumeIcon"
                                                 FontSize="20"
                                                 Icon="Solid_VolumeUp" />
-                                            <Button.Flyout>
+                                            <FlyoutBase.AttachedFlyout>
                                                 <Flyout>
                                                     <StackPanel Orientation="Horizontal">
                                                         <TextBlock Margin="0,0,10,8" VerticalAlignment="Bottom">0</TextBlock>
@@ -920,20 +931,22 @@
                                                         <TextBlock Margin="10,0,0,8" VerticalAlignment="Bottom">1</TextBlock>
                                                     </StackPanel>
                                                 </Flyout>
-                                            </Button.Flyout>
-                                        </Button>
+                                            </FlyoutBase.AttachedFlyout>
+                                        </HyperlinkButton>
 
-                                        <Button
+                                        <HyperlinkButton
                                             x:Name="BottomBtnQuality"
                                             Height="48"
                                             Padding="8,4,8,8"
                                             Background="Transparent"
                                             BorderThickness="0"
                                             FontSize="18"
+                                            FontWeight="Medium"
                                             Foreground="White"
                                             ToolTipService.ToolTip="清晰度"
+                                            Click="HyperlinkButtonOpenFlyout_OnClick"
                                             Visibility="{x:Bind Path=m_viewModel.Living, Mode=OneWay}">
-                                            <Button.Flyout>
+                                            <FlyoutBase.AttachedFlyout>
                                                 <Flyout>
                                                     <StackPanel Orientation="Horizontal">
                                                         <TextBlock
@@ -958,20 +971,22 @@
                                                             VerticalAlignment="Bottom" />
                                                     </StackPanel>
                                                 </Flyout>
-                                            </Button.Flyout>
-                                        </Button>
+                                            </FlyoutBase.AttachedFlyout>
+                                        </HyperlinkButton>
 
-                                        <Button
+                                        <HyperlinkButton
                                             x:Name="BottomBtnLine"
                                             Height="48"
                                             Padding="8,4,8,8"
                                             Background="Transparent"
                                             BorderThickness="0"
                                             FontSize="18"
+                                            FontWeight="Medium"
                                             Foreground="White"
                                             ToolTipService.ToolTip="线路"
+                                            Click="HyperlinkButtonOpenFlyout_OnClick"
                                             Visibility="{x:Bind Path=m_viewModel.Living, Mode=OneWay}">
-                                            <Button.Flyout>
+                                            <FlyoutBase.AttachedFlyout>
                                                 <Flyout>
                                                     <StackPanel Orientation="Horizontal">
                                                         <TextBlock
@@ -995,8 +1010,8 @@
                                                             VerticalAlignment="Bottom" />
                                                     </StackPanel>
                                                 </Flyout>
-                                            </Button.Flyout>
-                                        </Button>
+                                            </FlyoutBase.AttachedFlyout>
+                                        </HyperlinkButton>
 
                                         <HyperlinkButton
                                             x:Name="BottomBtnMiniWindows"

--- a/src/BiliLite.UWP/Pages/LiveDetailPage.xaml.cs
+++ b/src/BiliLite.UWP/Pages/LiveDetailPage.xaml.cs
@@ -1578,5 +1578,10 @@ namespace BiliLite.Pages
             WebPlayerToolbarControl.SetPlayer(m_player.WebPlayer);
             m_viewModel.ShowWebPlayerToolbar = true;
         }
+
+        private void HyperlinkButtonOpenFlyout_OnClick(object sender, RoutedEventArgs e)
+        {
+            FlyoutBase.ShowAttachedFlyout((FrameworkElement)sender);
+        }
     }
 }

--- a/src/BiliLite.UWP/ViewModels/Live/LiveRoomViewModel.cs
+++ b/src/BiliLite.UWP/ViewModels/Live/LiveRoomViewModel.cs
@@ -1186,6 +1186,7 @@ namespace BiliLite.ViewModels.Live
 
                 NotificationShowExtensions.ShowMessageToast(data.data?["send_tips"].ToString().Length > 0 ? data.data?["send_tips"].ToString() : "赠送成功"); // 鬼知道怎么有时候有返回提示有时候没有
                 await LoadWalletInfo();
+                await GetEmoticons(); // 礼物有可能刷新表情包
             }
             catch (CustomizedErrorException ex)
             {
@@ -1222,6 +1223,7 @@ namespace BiliLite.ViewModels.Live
                 }
                 NotificationShowExtensions.ShowMessageToast(data.data?["send_tips"].ToString().Length > 0 ? data.data?["send_tips"].ToString() : "赠送成功");
                 await LoadBag();
+                await GetEmoticons(); // 礼物有可能刷新表情包
             }
             catch (CustomizedErrorException ex)
             {


### PR DESCRIPTION
1. 改进了直播间播放工具按钮，现在统一使用HyperlinkButton. 因此修复了之前的鼠标移到某些按钮上再移开会导致按钮变色进而看不见的问题
2. 右上角几个按钮改用FontAwesome字体实现，基本实现统一化播放器界面的按钮设计
3. 剧场模式下方的宽弹幕输入框旁的表情按钮背景取消透明，因为这有可能导致在视频上下有黑边或视频整体较白的情况下无法识别表情按钮
4. https://github.com/ywmoyue/biliuwp-lite/issues/981#issuecomment-2582468344 调整了黄豆表情在表情Flyout中的大小