### PR TITLE
优化单页面模式返回和主页按钮背景高度

### DIFF
--- a/src/BiliLite.UWP/NoTabMainPage.xaml
+++ b/src/BiliLite.UWP/NoTabMainPage.xaml
@@ -46,7 +46,7 @@
             <Button
                 x:Name="btnBack"
                 Width="48"
-                Height="40"
+                Height="32"
                 Margin="0,-4"
                 Background="Transparent"
                 BorderThickness="0"
@@ -61,7 +61,7 @@
         x:Name="btnHome"
         Grid.Column="1"
         Width="48"
-        Height="40"
+        Height="32"
         Margin="0,-4"
         Background="Transparent"
         BorderThickness="0"


### PR DESCRIPTION
win11下他俩的背景会超出标题栏，挡住一点视频，win10未知。