### PR TITLE
修复Star History图表显示异常的链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ git clone -b dev https://github.com/ywmoyue/biliuwp-lite.git
 </a>
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=ywmoyue/biliuwp-lite&type=Date&theme=dark"/>
-  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=ywmoyue/biliuwp-lite&type=Date"/>
-  <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=ywmoyue/biliuwp-lite&type=Date"/>
+  <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=ywmoyue/biliuwp-lite&type=Date&theme=dark"/>
+  <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=ywmoyue/biliuwp-lite&type=Date"/>
+  <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=ywmoyue/biliuwp-lite&type=Date"/>
 </picture>


### PR DESCRIPTION
当前README中的Star History图表因GitHub stargazer API限制已无法正常加载。本项目改用无需API token、使用同一域名提供数据的新方案star-history.dera.page，与众多主流项目一致。本次仅将主页Stars图表的链接切换到新数据源，未改动其他内容，以恢复首页Star历史图表的正常展示。